### PR TITLE
Include ssmdocs directory in build tarballs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ python: prep
 	@cp -r pre.d /tmp/ec2rl
 	@cp -r docs /tmp/ec2rl
 	@cp -r exampleconfigs /tmp/ec2rl
+	@cp -r ssmdocs /tmp/ec2rl
 	@cp functions.bash /tmp/ec2rl
 	@cp README.md /tmp/ec2rl
 	@cp requirements.txt /tmp/ec2rl
@@ -52,6 +53,7 @@ binary: prep
 	--add-data "bin:bin" \
 	--add-data "docs:docs" \
 	--add-data "exampleconfigs:exampleconfigs" \
+	--add-data "ssmdocs:ssmdocs" \
 	--add-data "pre.d:pre.d" \
 	--add-data "mod.d:mod.d" \
 	--add-data "post.d:post.d" \


### PR DESCRIPTION
The Makefile explicitly includes which files are added to the tarballs. This commit updates the Makefile to include the ssmdocs directory. This was tested by building new tarballs and manually verifying the directory and its contents were present.