### PR TITLE
Bug and verbiage fixes in several modules

### DIFF
--- a/mod.d/aptlog.yaml
+++ b/mod.d/aptlog.yaml
@@ -17,9 +17,9 @@
 name: !!str aptlog
 path: !!str
 version: !!str 1.0
-title: !!str Collect apt log files
+title: !!str Gather /var/log/apt and /var/log/dpkg.log files
 helptext: !!str |
-  Collect apt log files
+  Gather /var/log/apt and /var/log/dpkg.log files
 placement: !!str run
 package: 
   - !!str
@@ -37,17 +37,17 @@ content: !!str |
   # read-in shared function
   source functions.bash
 
-  echo "I will collect the apt log files from this machine"
+  echo "I will gather the /var/log/apt and /var/log/dpkg.log files from this machine"
 
   if [[ -r /var/log/apt && -r /var/log/dpkg.log ]]
       then
           mkdir $EC2RL_GATHEREDDIR/aptlog
           cp -r /var/log/apt/* $EC2RL_GATHEREDDIR/aptlog || true
           cp /var/log/dpkg.log $EC2RL_GATHEREDDIR/aptlog || true
-          echo "I have attempted to copy the apt log files to ${EC2RL_GATHEREDDIR}/aptlog"
+          echo "I have attempted to copy the /var/log/apt and /var/log/dpkg.log files to ${EC2RL_GATHEREDDIR}/aptlog"
 
       else
-          echo "No apt log files available or permission denied"
+          echo "No /var/log/apt or /var/log/dpkg.log files available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False

--- a/mod.d/atophistory.yaml
+++ b/mod.d/atophistory.yaml
@@ -17,9 +17,9 @@
 name: !!str atophistory
 path: !!str
 version: !!str 1.0
-title: !!str Collect historical atop files.
+title: !!str Gather /var/log/atop history files
 helptext: !!str |
-  Collect historical atop files
+  Gather /var/log/atop history files
   Requires atop tool ( http://www.atoptool.nl/ )
 placement: !!str run
 package: 
@@ -38,15 +38,15 @@ content: !!str |
   # read-in shared function
   source functions.bash
 
-  echo "I will collect historical atop files from this machine"
+  echo "I will gather /var/log/atop history files from this machine"
 
   if [ -r /var/log/atop ]
       then
           mkdir $EC2RL_GATHEREDDIR/atophistory
           cp -r /var/log/atop/* $EC2RL_GATHEREDDIR/atophistory || true
-          echo "I have attempted to copy the atophistory files to ${EC2RL_GATHEREDDIR}/atophistory"
+          echo "I have attempted to copy the /var/log/atop history files to ${EC2RL_GATHEREDDIR}/atophistory"
       else
-          echo "No atop history files available or permission denied"
+          echo "No /var/log/atop history files available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False

--- a/mod.d/cloudinitlog.yaml
+++ b/mod.d/cloudinitlog.yaml
@@ -17,9 +17,9 @@
 name: !!str cloudinitlog
 path: !!str
 version: !!str 1.0
-title: !!str Collect cloud-init log files
+title: !!str Gather up /etc/cloud-init* log files
 helptext: !!str |
-  Collect cloud-init log files
+  Gather up /etc/cloud-init* log files
 placement: !!str run
 package: 
   - !!str
@@ -37,15 +37,15 @@ content: !!str |
   # read-in shared function
   source functions.bash
 
-  echo "I will collect cloud-init log files from this machine"
+  echo "I will collect /etc/cloud-init* log files from this machine"
 
   if [[ -r /var/log/cloud-init.log && -r /var/log/cloud-init-output.log ]]
       then
           mkdir $EC2RL_GATHEREDDIR/cloudinitlog
           cp /var/log/cloud-init* $EC2RL_GATHEREDDIR/cloudinitlog || true
-          echo "I have attempted to copy the cloudinit log files to ${EC2RL_GATHEREDDIR}/cloudinitlog"
+          echo "I have attempted to copy the /etc/cloud-init* log files to ${EC2RL_GATHEREDDIR}/cloudinitlog"
       else
-          echo "No cloud init log files available or permission denied"
+          echo "No /etc/cloud-init* log files available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False
@@ -55,6 +55,6 @@ constraint:
   required: !!str
   optional: !!str
   software: !!str
-  sudo: !!str True
+  sudo: !!str False
   perfimpact: !!str False
   parallelexclusive: !!str

--- a/mod.d/collectlhistory.yaml
+++ b/mod.d/collectlhistory.yaml
@@ -17,9 +17,9 @@
 name: !!str collectlhistory
 path: !!str
 version: !!str 1.0
-title: !!str Collect historical collectl files
+title: !!str Gather /var/log/collectl history files
 helptext: !!str |
-  Collect historical collectl files
+  Gather /var/log/collectl history files
   Requires collectl tool ( http://collectl.sourceforge.net/ )
 placement: !!str run
 package: 
@@ -38,15 +38,15 @@ content: !!str |
   # read-in shared function
   source functions.bash
 
-  echo "I will collect historical collectl files from this machine"
+  echo "I will gather /var/log/collectl history files from this machine"
 
   if [ -r /var/log/collectl ]
       then
           mkdir $EC2RL_GATHEREDDIR/collectlhistory
           cp -r /var/log/collectl/* $EC2RL_GATHEREDDIR/collectlhistory || true
-          echo "I have attempted to copy the collectl history files to ${EC2RL_GATHEREDDIR}/collectlhistory"
+          echo "I have attempted to copy the /var/log/collectl history files to ${EC2RL_GATHEREDDIR}/collectlhistory"
       else
-          echo "No collectl history files available or permission denied"
+          echo "No /var/log/collectl h history files available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False

--- a/mod.d/dmesg.yaml
+++ b/mod.d/dmesg.yaml
@@ -17,9 +17,9 @@
 name: !!str dmesg
 path: !!str
 version: !!str 1.0
-title: !!str Collect dmesg files
+title: !!str Gather /var/log/dmesg* files
 helptext: !!str |
-  Collect dmesg files
+  Gather /var/log/dmesg* files
 placement: !!str run
 package: 
   - !!str
@@ -37,15 +37,15 @@ content: !!str |
   # read-in shared function
   source functions.bash
 
-  echo "I will collect dmesg files from this machine"
+  echo "I will gather /var/log/dmesg* files from this machine"
 
   if [ -r /var/log/dmesg ]
       then
           mkdir $EC2RL_GATHEREDDIR/dmesg
           cp -r /var/log/dmesg* $EC2RL_GATHEREDDIR/dmesg || true
-          echo "I have attempted to copy the dmesg file to ${EC2RL_GATHEREDDIR}/dmesg"
+          echo "I have attempted to copy the /var/log/dmesg* files to ${EC2RL_GATHEREDDIR}/dmesg"
       else
-          echo "No dmesg files available or permission denied"
+          echo "No /var/log/dmesg* files available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False

--- a/mod.d/httpdlogs.yaml
+++ b/mod.d/httpdlogs.yaml
@@ -17,9 +17,9 @@
 name: !!str httpdlogs
 path: !!str
 version: !!str 1.0
-title: !!str Collect apache httpd log files
+title: !!str Gather up Apache /var/log/httpd/* or /var/log/apache2/* log files
 helptext: !!str |
-  Collect apache httpd log files. This assumes default paths.
+  Gather up Apache /var/log/httpd/* or /var/log/apache2/* log files This assumes default paths.
 placement: !!str run
 package: 
   - !!str
@@ -37,20 +37,20 @@ content: !!str |
   # read-in shared function
   source functions.bash
 
-  echo "I will collect apache httpd log files from this machine"
+  echo "I will collect Apache httpd log files from this machine"
 
   if [ -r /var/log/httpd ]
       then
           mkdir $EC2RL_GATHEREDDIR/httpdlogs
           cp -r /var/log/httpd/* $EC2RL_GATHEREDDIR/httpdlogs || true
-          echo "I have attempted to copy the httpd log files to ${EC2RL_GATHEREDDIR}/httpdlogs"
+          echo "I have attempted to copy the Apache /var/log/httpd/* log files to ${EC2RL_GATHEREDDIR}/httpdlogs"
   elif [ -r /var/log/apache2 ]
       then
           mkdir $EC2RL_GATHEREDDIR/httpdlogs
           cp -r /var/log/apache2/* $EC2RL_GATHEREDDIR/httpdlogs || true
-          echo "I have attempted to copy the httpd log files to ${EC2RL_GATHEREDDIR}/httpdlogs"
+          echo "I have attempted to copy the Apache /var/log/apache2/* log files to ${EC2RL_GATHEREDDIR}/httpdlogs"
   else
-      echo "No apache httpd log files available or permission denied"
+      echo "No Apache /var/log/httpd/* or /var/log/apache2/* log files available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False

--- a/mod.d/ltrace.yaml
+++ b/mod.d/ltrace.yaml
@@ -17,10 +17,11 @@
 name: !!str ltrace
 path: !!str
 version: !!str 1.0
-title: !!str Collect output from ltrace -fp for application analysis
+title: !!str Gather output from ltrace -fp for application analysis
 helptext: !!str |
-  Collect output from ltrace -fp for application analysis
-  Requires --period= for time period between repetition
+  Gather output from ltrace -fp for application analysis
+  Requires --period= for time period to trace
+  Requires --pid= for pid to trace
   Incompatible with parallel mode due to ptrace functionality.
 placement: !!str run
 package: 
@@ -39,11 +40,11 @@ content: !!str |
   # read-in shared function
   source functions.bash
 
-  echo "I will collect ltrace -fp output from this $EC2RL_DISTRO box for $period seconds."
+  echo "I will gather ltrace -fp output from this $EC2RL_DISTRO box for $period seconds."
 
   mkdir $EC2RL_GATHEREDDIR/ltrace
 
-  echo "I have attempted to copy the ltrace output to ${EC2RL_GATHEREDDIR}/ltrace"
+  echo "I have attempted to copy the ltrace -fp output to ${EC2RL_GATHEREDDIR}/ltrace"
   timeout $period ltrace -fp $pid -o $EC2RL_GATHEREDDIR/ltrace/ltrace.out
   exit 0
 constraint:

--- a/mod.d/messages.yaml
+++ b/mod.d/messages.yaml
@@ -17,9 +17,9 @@
 name: !!str messages
 path: !!str
 version: !!str 1.0
-title: !!str Collect messages files
+title: !!str Gather up /var/log/messages* or /var/log/syslog* files
 helptext: !!str |
-  Collect messages files
+  Gather up /var/log/messages* or /var/log/syslog* files
 placement: !!str run
 package: 
   - !!str
@@ -37,20 +37,20 @@ content: !!str |
   # read-in shared function
   source functions.bash
 
-  echo "I will collect messages/syslog files from this machine"
+  echo "I will collect /var/log/messages* or /var/log/syslog* files from this machine"
 
   if [ -r /var/log/messages ]
       then
           mkdir $EC2RL_GATHEREDDIR/messages
           cp -r /var/log/messages* $EC2RL_GATHEREDDIR/messages || true
-          echo "I have attempted to copy the messages files to ${EC2RL_GATHEREDDIR}/messages"
+          echo "I have attempted to copy the /var/log/messages* files to ${EC2RL_GATHEREDDIR}/messages"
   elif [ -r /var/log/syslog ]
       then
           mkdir $EC2RL_GATHEREDDIR/messages
           cp -r /var/log/syslog* $EC2RL_GATHEREDDIR/messages || true
-          echo "I have attempted to copy the messages files to ${EC2RL_GATHEREDDIR}/messages"
+          echo "I have attempted to copy the /var/log/syslog* files to ${EC2RL_GATHEREDDIR}/messages"
   else
-      echo "No messages/syslog files available or permission denied"
+      echo "No /var/log/messages* or /var/log/syslog* files available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False

--- a/mod.d/mysqldlog.yaml
+++ b/mod.d/mysqldlog.yaml
@@ -17,9 +17,9 @@
 name: !!str mysqldlog
 path: !!str
 version: !!str 1.0
-title: !!str Collect mysqld.log files
+title: !!str Gather /var/log/mysqld.log* files
 helptext: !!str |
-  Collect mysqld.log files
+  Gather /var/log/mysqld.log* files
 placement: !!str run
 package: 
   - !!str
@@ -37,15 +37,15 @@ content: !!str |
   # read-in shared function
   source functions.bash
 
-  echo "I will collect mysqld.log files from this machine"
+  echo "I will gather /var/log/mysqld.log* files from this machine"
 
   if [ -r /var/log/mysqld.log ]
       then
           mkdir $EC2RL_GATHEREDDIR/mysqldlog
           cp -r /var/log/mysqld.log* $EC2RL_GATHEREDDIR/mysqldlog
-          echo "I have attempted to copy the mysqld log files to ${EC2RL_GATHEREDDIR}/mysqldlog"
+          echo "I have attempted to copy the /var/log/mysqld.log* files to ${EC2RL_GATHEREDDIR}/mysqldlog"
       else
-          echo "No mysqld.log file available or permission denied"
+          echo "No /var/log/mysqld.log* file available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False
@@ -55,6 +55,6 @@ constraint:
   required: !!str
   optional: !!str
   software: !!str
-  sudo: !!str False
+  sudo: !!str True
   perfimpact: !!str False
   parallelexclusive: !!str

--- a/mod.d/nginxlogs.yaml
+++ b/mod.d/nginxlogs.yaml
@@ -17,9 +17,9 @@
 name: !!str nginxlogs
 path: !!str
 version: !!str 1.0
-title: !!str Collect nginx log files
+title: !!str Gather up /var/log/nginx/* log files
 helptext: !!str |
-  Collect nginx log files. This assumes default paths.
+  Gather up /var/log/nginx/* log files. This assumes default paths.
 placement: !!str run
 package: 
   - !!str
@@ -37,15 +37,15 @@ content: !!str |
   # read-in shared function
   source functions.bash
 
-  echo "I will collect nginx log files from this machine"
+  echo "I will gather /var/log/nginx/* log files from this machine"
 
   if [ -r /var/log/nginx ]
       then
           mkdir $EC2RL_GATHEREDDIR/nginxlogs
           cp -r /var/log/nginx/* $EC2RL_GATHEREDDIR/nginxlogs || true
-          echo "I have attempted to copy the nginx log files to ${EC2RL_GATHEREDDIR}/nginxlogs"
+          echo "I have attempted to copy the /var/log/nginx/* log files to ${EC2RL_GATHEREDDIR}/nginxlogs"
       else
-          echo "No nginx log files available or permission denied"
+          echo "No /var/log/nginx/* log files available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False

--- a/mod.d/nsswitch.yaml
+++ b/mod.d/nsswitch.yaml
@@ -17,9 +17,9 @@
 name: !!str nsswitch
 path: !!str
 version: !!str 1.0
-title: !!str Collect nsswitch.conf file
+title: !!str Gather up /etc/nsswitch.conf file
 helptext: !!str |
-  Collect nsswitch.conf file
+  Gather up /etc/nsswitch.conf file
 placement: !!str run
 package: 
   - !!str
@@ -37,15 +37,15 @@ content: !!str |
   # read-in shared function
   source functions.bash
 
-  echo "I will collect the nsswitch.conf file from this machine"
+  echo "I will gather the /etc/nsswitch.conf file from this machine"
 
   if [ -r /etc/nsswitch.conf ]
       then
           mkdir $EC2RL_GATHEREDDIR/nsswitch
           cp /etc/nsswitch.conf $EC2RL_GATHEREDDIR/nsswitch/ || true
-          echo "I have attempted to copy the nsswitch file to ${EC2RL_GATHEREDDIR}/nsswitch"
+          echo "I have attempted to copy the /etc/nsswitch.conf file to ${EC2RL_GATHEREDDIR}/nsswitch"
       else
-          echo "No nsswitch.conf available or permission denied"
+          echo "No /etc/nsswitch.conf available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False

--- a/mod.d/resolvconf.yaml
+++ b/mod.d/resolvconf.yaml
@@ -17,9 +17,9 @@
 name: !!str resolvconf
 path: !!str
 version: !!str 1.0
-title: !!str Collect output from /etc/resolv.conf for review
+title: !!str Gather the /etc/resolv.conf file
 helptext: !!str |
-  Collect output from /etc/resolv.conf for review.
+  Gather the /etc/resolv.conf file
 placement: !!str run
 package: 
   - !!str
@@ -37,15 +37,15 @@ content: !!str |
   # read-in shared function
   source functions.bash
 
-  echo "I will collect the resolv.conf file from this machine"
+  echo "I will gather the /etc/resolv.conf filefile from this machine"
 
   if [ -r /etc/resolv.conf ]
       then
           mkdir $EC2RL_GATHEREDDIR/resolvconf
           cp /etc/resolv.conf $EC2RL_GATHEREDDIR/resolvconf/ || true
-          echo "I have attempted to copy the resolv.conf file to ${EC2RL_GATHEREDDIR}/resolvconf"
+          echo "I have attempted to copy the /etc/resolv.conf file to ${EC2RL_GATHEREDDIR}/resolvconf"
       else
-          echo "No resolv.conf available or permission denied"
+          echo "No /etc/resolv.conf available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False

--- a/mod.d/sarhistory.yaml
+++ b/mod.d/sarhistory.yaml
@@ -17,9 +17,9 @@
 name: !!str sarhistory
 path: !!str
 version: !!str 1.0
-title: !!str Collect historical sar files
+title: !!str Gather up /var/log/sa (sar) history files
 helptext: !!str |
-  Collect historical sar files
+  Gather up /var/log/sa (sar) history files
   sar is provided by the sysstat package
 placement: !!str run
 package: 
@@ -38,20 +38,20 @@ content: !!str |
   # read-in shared function
   source functions.bash
 
-  echo "I will collect historical sar files from this machine"
+  echo "I will gather /var/log/sa (sar) history files from this machine"
 
   if [ -r /var/log/sa ]
       then
           mkdir $EC2RL_GATHEREDDIR/sarhistory
           cp -r /var/log/sa/* $EC2RL_GATHEREDDIR/sarhistory || true
-          echo "I have attempted to copy the sar history files to ${EC2RL_GATHEREDDIR}/sarhistory"
+          echo "I have attempted to copy the /var/log/sa history files to ${EC2RL_GATHEREDDIR}/sarhistory"
   elif [ -r /var/log/sysstat ]
       then
           mkdir $EC2RL_GATHEREDDIR/sarhistory
           cp -r /var/log/sysstat/* $EC2RL_GATHEREDDIR/sarhistory || true
-          echo "I have attempted to copy the sar history files to ${EC2RL_GATHEREDDIR}/sarhistory"
+          echo "I have attempted to copy the /var/log/sysstat history files to ${EC2RL_GATHEREDDIR}/sarhistory"
   else
-      echo "No sar history files available or permission denied"
+      echo "No /var/log/sa or /var/log/sysstat history files available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False

--- a/mod.d/strace.yaml
+++ b/mod.d/strace.yaml
@@ -17,10 +17,11 @@
 name: !!str strace
 path: !!str
 version: !!str 1.0
-title: !!str Collect output from strace -fp for application analysis
+title: !!str Gather output from strace -fp for application analysis
 helptext: !!str |
-  Collect output from strace -fp for application analysis
+  Gather output from strace -fp for application analysis
   Requires --period= for time period between repetition
+  Requires --pid= for pid to trace
   Incompatible with parallel mode due to ptrace functionality.
 placement: !!str run
 package: 
@@ -39,11 +40,11 @@ content: !!str |
   # read-in shared function
   source functions.bash
 
-  echo "I will collect strace -fp output from this $EC2RL_DISTRO box for $period seconds"
+  echo "I will gather strace -fp output from this $EC2RL_DISTRO box for $period seconds"
 
   mkdir $EC2RL_GATHEREDDIR/strace
 
-  echo "I have attempted to copy the strace output to ${EC2RL_GATHEREDDIR}/strace"
+  echo "I have attempted to copy the strace -fp output to ${EC2RL_GATHEREDDIR}/strace"
   timeout $period strace -fp $pid -o $EC2RL_GATHEREDDIR/strace/strace.out
   exit 0
 constraint:

--- a/mod.d/tcpdump.yaml
+++ b/mod.d/tcpdump.yaml
@@ -17,9 +17,9 @@
 name: !!str tcpdump
 path: !!str
 version: !!str 1.0
-title: !!str Collect packet capture for network troubleshooting.
+title: !!str Gather packet capture for network troubleshooting.
 helptext: !!str |
-  Collect packet capture for network troubleshooting.
+  Gather packet capture for network troubleshooting.
   Requires --interface= to determine interface to capture (usually eth0)
   Requires --count= to determine number of packets to capture
   Requires --period= to determine length of time to run for
@@ -79,7 +79,7 @@ content: !!str |
 
 
 
-  echo "I will collect tcpdump from this $EC2RL_DISTRO box."
+  echo "I will gather a tcpdump from this $EC2RL_DISTRO box."
 
 
   mkdir $EC2RL_GATHEREDDIR/tcpdump

--- a/mod.d/yumlog.yaml
+++ b/mod.d/yumlog.yaml
@@ -17,9 +17,9 @@
 name: !!str yumlog
 path: !!str
 version: !!str 1.0
-title: !!str Collect yum.log file
+title: !!str Gather up /var/log/yum.log file
 helptext: !!str |
-  Collect yum.log file
+  Gather up /var/log/yum.log file
 placement: !!str run
 package: 
   - !!str
@@ -37,15 +37,15 @@ content: !!str |
   # read-in shared function
   source functions.bash
 
-  echo "I will collect the yumlog file from this machine"
+  echo "I will gather the /var/log/yum.log file from this machine"
 
   if [ -r /var/log/yum.log ]
       then
           mkdir $EC2RL_GATHEREDDIR/yumlog
           cp /var/log/yum.log $EC2RL_GATHEREDDIR/yumlog || true
-          echo "I have attempted to copy the yum log files to ${EC2RL_GATHEREDDIR}/yumlog"
+          echo "I have attempted to copy the /var/logyum.log file to ${EC2RL_GATHEREDDIR}/yumlog"
       else
-          echo "No yum.log available or permission denied"
+          echo "No /var/log/yum.log available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False

--- a/mod.d/zypperlog.yaml
+++ b/mod.d/zypperlog.yaml
@@ -17,9 +17,9 @@
 name: !!str zypperlog
 path: !!str
 version: !!str 1.0
-title: !!str Collect zypper log files
+title: !!str Gather /var/log/zypp and zypper.log log files
 helptext: !!str |
-  Collect zypper log files
+  Gather /var/log/zypp and zypper.log log files
 placement: !!str run
 package: 
   - !!str
@@ -37,17 +37,17 @@ content: !!str |
   # read-in shared function
   source functions.bash
 
-  echo "I will collect the zypper log files from this machine"
+  echo "I will gather /var/log/zypp and zypper.log log files from this machine"
 
   if [[ -r /var/log/zypp && -r /var/log/zypper.log ]]
       then
           mkdir $EC2RL_GATHEREDDIR/zypperlog
           cp -r /var/log/zypp/* $EC2RL_GATHEREDDIR/zypperlog || true
-          cp /var/log/zypper.log $EC2RL_GATHEREDDIR/zypperlog || true
-          echo "I have attempted to copy the zypper log files to ${EC2RL_GATHEREDDIR}/zypperlog"
+          cp /var/log/zypper.log* $EC2RL_GATHEREDDIR/zypperlog || true
+          echo "I have attempted to copy the /var/log/zypp and zypper.log  log files to ${EC2RL_GATHEREDDIR}/zypperlog"
 
       else
-          echo "No zypper log files available or permission denied"
+          echo "No /var/log/zypp or zypper.log log files available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False


### PR DESCRIPTION
Fix several missing requirements for the help (ltrace/strace modules), zypperlog not grabbing logrotated files (didn't catch the .xz named files!), and reworded Gather modules to actually say gather instead of collect