### PR TITLE
Fix indention and verbiage in all gather modules

### DIFF
--- a/mod.d/aptlog.yaml
+++ b/mod.d/aptlog.yaml
@@ -39,15 +39,13 @@ content: !!str |
 
   echo "I will gather the /var/log/apt and /var/log/dpkg.log files from this machine"
 
-  if [[ -r /var/log/apt && -r /var/log/dpkg.log ]]
-      then
-          mkdir $EC2RL_GATHEREDDIR/aptlog
-          cp -r /var/log/apt/* $EC2RL_GATHEREDDIR/aptlog || true
-          cp /var/log/dpkg.log $EC2RL_GATHEREDDIR/aptlog || true
-          echo "I have attempted to copy the /var/log/apt and /var/log/dpkg.log files to ${EC2RL_GATHEREDDIR}/aptlog"
-
-      else
-          echo "No /var/log/apt or /var/log/dpkg.log files available or permission denied"
+  if [[ -r /var/log/apt && -r /var/log/dpkg.log ]]; then
+      mkdir $EC2RL_GATHEREDDIR/aptlog
+      cp -r /var/log/apt/* $EC2RL_GATHEREDDIR/aptlog || true
+      cp /var/log/dpkg.log $EC2RL_GATHEREDDIR/aptlog || true
+      echo "I have attempted to copy the /var/log/apt and /var/log/dpkg.log files to ${EC2RL_GATHEREDDIR}/aptlog"
+  else
+      echo "No /var/log/apt or /var/log/dpkg.log files available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False

--- a/mod.d/atophistory.yaml
+++ b/mod.d/atophistory.yaml
@@ -40,13 +40,12 @@ content: !!str |
 
   echo "I will gather /var/log/atop history files from this machine"
 
-  if [ -r /var/log/atop ]
-      then
-          mkdir $EC2RL_GATHEREDDIR/atophistory
-          cp -r /var/log/atop/* $EC2RL_GATHEREDDIR/atophistory || true
-          echo "I have attempted to copy the /var/log/atop history files to ${EC2RL_GATHEREDDIR}/atophistory"
-      else
-          echo "No /var/log/atop history files available or permission denied"
+  if [ -r /var/log/atop ]; then
+      mkdir $EC2RL_GATHEREDDIR/atophistory
+      cp -r /var/log/atop/* $EC2RL_GATHEREDDIR/atophistory || true
+      echo "I have attempted to copy the /var/log/atop history files to ${EC2RL_GATHEREDDIR}/atophistory"
+  else
+      echo "No /var/log/atop history files available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False

--- a/mod.d/cloudinitlog.yaml
+++ b/mod.d/cloudinitlog.yaml
@@ -17,9 +17,9 @@
 name: !!str cloudinitlog
 path: !!str
 version: !!str 1.0
-title: !!str Gather up /etc/cloud-init* log files
+title: !!str Gather /etc/cloud-init* log files
 helptext: !!str |
-  Gather up /etc/cloud-init* log files
+  Gather /etc/cloud-init* log files
 placement: !!str run
 package: 
   - !!str
@@ -39,13 +39,12 @@ content: !!str |
 
   echo "I will collect /etc/cloud-init* log files from this machine"
 
-  if [[ -r /var/log/cloud-init.log && -r /var/log/cloud-init-output.log ]]
-      then
-          mkdir $EC2RL_GATHEREDDIR/cloudinitlog
-          cp /var/log/cloud-init* $EC2RL_GATHEREDDIR/cloudinitlog || true
-          echo "I have attempted to copy the /etc/cloud-init* log files to ${EC2RL_GATHEREDDIR}/cloudinitlog"
-      else
-          echo "No /etc/cloud-init* log files available or permission denied"
+  if [[ -r /var/log/cloud-init.log && -r /var/log/cloud-init-output.log ]]; then
+      mkdir $EC2RL_GATHEREDDIR/cloudinitlog
+      cp /var/log/cloud-init* $EC2RL_GATHEREDDIR/cloudinitlog || true
+      echo "I have attempted to copy the /etc/cloud-init* log files to ${EC2RL_GATHEREDDIR}/cloudinitlog"
+  else
+      echo "No /etc/cloud-init* log files available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False

--- a/mod.d/collectlhistory.yaml
+++ b/mod.d/collectlhistory.yaml
@@ -40,13 +40,12 @@ content: !!str |
 
   echo "I will gather /var/log/collectl history files from this machine"
 
-  if [ -r /var/log/collectl ]
-      then
-          mkdir $EC2RL_GATHEREDDIR/collectlhistory
-          cp -r /var/log/collectl/* $EC2RL_GATHEREDDIR/collectlhistory || true
-          echo "I have attempted to copy the /var/log/collectl history files to ${EC2RL_GATHEREDDIR}/collectlhistory"
-      else
-          echo "No /var/log/collectl h history files available or permission denied"
+  if [ -r /var/log/collectl ]; then
+      mkdir $EC2RL_GATHEREDDIR/collectlhistory
+      cp -r /var/log/collectl/* $EC2RL_GATHEREDDIR/collectlhistory || true
+      echo "I have attempted to copy the /var/log/collectl history files to ${EC2RL_GATHEREDDIR}/collectlhistory"
+  else
+      echo "No /var/log/collectl h history files available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False

--- a/mod.d/dmesg.yaml
+++ b/mod.d/dmesg.yaml
@@ -39,13 +39,12 @@ content: !!str |
 
   echo "I will gather /var/log/dmesg* files from this machine"
 
-  if [ -r /var/log/dmesg ]
-      then
-          mkdir $EC2RL_GATHEREDDIR/dmesg
-          cp -r /var/log/dmesg* $EC2RL_GATHEREDDIR/dmesg || true
-          echo "I have attempted to copy the /var/log/dmesg* files to ${EC2RL_GATHEREDDIR}/dmesg"
-      else
-          echo "No /var/log/dmesg* files available or permission denied"
+  if [ -r /var/log/dmesg ]; then
+      mkdir $EC2RL_GATHEREDDIR/dmesg
+      cp -r /var/log/dmesg* $EC2RL_GATHEREDDIR/dmesg || true
+      echo "I have attempted to copy the /var/log/dmesg* files to ${EC2RL_GATHEREDDIR}/dmesg"
+  else
+      echo "No /var/log/dmesg* files available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False

--- a/mod.d/fstab.yaml
+++ b/mod.d/fstab.yaml
@@ -37,13 +37,12 @@ content: !!str |
 
   echo "I will gather the /etc/fstab file from this machine"
 
-  if [[ -r /etc/fstab ]]
-      then
-          mkdir $EC2RL_GATHEREDDIR/fstab
-          cp /etc/fstab $EC2RL_GATHEREDDIR/fstab || true
-          echo "I have attempted to copy the /etc/fstab file to ${EC2RL_GATHEREDDIR}/fstab"
-      else
-          echo "No cloud init log files available or permission denied"
+  if [[ -r /etc/fstab ]]; then
+      mkdir $EC2RL_GATHEREDDIR/fstab
+      cp /etc/fstab $EC2RL_GATHEREDDIR/fstab || true
+      echo "I have attempted to copy the /etc/fstab file to ${EC2RL_GATHEREDDIR}/fstab"
+  else
+      echo "No cloud init log files available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False

--- a/mod.d/httpdlogs.yaml
+++ b/mod.d/httpdlogs.yaml
@@ -17,9 +17,9 @@
 name: !!str httpdlogs
 path: !!str
 version: !!str 1.0
-title: !!str Gather up Apache /var/log/httpd/* or /var/log/apache2/* log files
+title: !!str Gather Apache /var/log/httpd/* or /var/log/apache2/* log files
 helptext: !!str |
-  Gather up Apache /var/log/httpd/* or /var/log/apache2/* log files This assumes default paths.
+  Gather Apache /var/log/httpd/* or /var/log/apache2/* log files This assumes default paths.
 placement: !!str run
 package: 
   - !!str
@@ -39,16 +39,14 @@ content: !!str |
 
   echo "I will collect Apache httpd log files from this machine"
 
-  if [ -r /var/log/httpd ]
-      then
-          mkdir $EC2RL_GATHEREDDIR/httpdlogs
-          cp -r /var/log/httpd/* $EC2RL_GATHEREDDIR/httpdlogs || true
-          echo "I have attempted to copy the Apache /var/log/httpd/* log files to ${EC2RL_GATHEREDDIR}/httpdlogs"
-  elif [ -r /var/log/apache2 ]
-      then
-          mkdir $EC2RL_GATHEREDDIR/httpdlogs
-          cp -r /var/log/apache2/* $EC2RL_GATHEREDDIR/httpdlogs || true
-          echo "I have attempted to copy the Apache /var/log/apache2/* log files to ${EC2RL_GATHEREDDIR}/httpdlogs"
+  if [ -r /var/log/httpd ]; then
+      mkdir $EC2RL_GATHEREDDIR/httpdlogs
+      cp -r /var/log/httpd/* $EC2RL_GATHEREDDIR/httpdlogs || true
+      echo "I have attempted to copy the Apache /var/log/httpd/* log files to ${EC2RL_GATHEREDDIR}/httpdlogs"
+  elif [ -r /var/log/apache2 ]; then
+      mkdir $EC2RL_GATHEREDDIR/httpdlogs
+      cp -r /var/log/apache2/* $EC2RL_GATHEREDDIR/httpdlogs || true
+      echo "I have attempted to copy the Apache /var/log/apache2/* log files to ${EC2RL_GATHEREDDIR}/httpdlogs"
   else
       echo "No Apache /var/log/httpd/* or /var/log/apache2/* log files available or permission denied"
   fi

--- a/mod.d/journal.yaml
+++ b/mod.d/journal.yaml
@@ -17,9 +17,9 @@
 name: !!str journal
 path: !!str
 version: !!str 1.0
-title: !!str Collect journal output
+title: !!str Gather journal output
 helptext: !!str |
-  Collect journal output
+  Gather journal output
 placement: !!str run
 package: 
   - !!str
@@ -37,7 +37,7 @@ content: !!str |
   # read-in shared function
   source functions.bash
 
-  echo "I will collect the journal from this machine"
+  echo "I will gather the journal from this machine"
 
   mkdir $EC2RL_GATHEREDDIR/journal
   journalctl -qxl > $EC2RL_GATHEREDDIR/journal/journal.out

--- a/mod.d/messages.yaml
+++ b/mod.d/messages.yaml
@@ -17,9 +17,9 @@
 name: !!str messages
 path: !!str
 version: !!str 1.0
-title: !!str Gather up /var/log/messages* or /var/log/syslog* files
+title: !!str Gather /var/log/messages* or /var/log/syslog* files
 helptext: !!str |
-  Gather up /var/log/messages* or /var/log/syslog* files
+  Gather /var/log/messages* or /var/log/syslog* files
 placement: !!str run
 package: 
   - !!str
@@ -39,16 +39,14 @@ content: !!str |
 
   echo "I will collect /var/log/messages* or /var/log/syslog* files from this machine"
 
-  if [ -r /var/log/messages ]
-      then
-          mkdir $EC2RL_GATHEREDDIR/messages
-          cp -r /var/log/messages* $EC2RL_GATHEREDDIR/messages || true
-          echo "I have attempted to copy the /var/log/messages* files to ${EC2RL_GATHEREDDIR}/messages"
-  elif [ -r /var/log/syslog ]
-      then
-          mkdir $EC2RL_GATHEREDDIR/messages
-          cp -r /var/log/syslog* $EC2RL_GATHEREDDIR/messages || true
-          echo "I have attempted to copy the /var/log/syslog* files to ${EC2RL_GATHEREDDIR}/messages"
+  if [ -r /var/log/messages ]; then
+      mkdir $EC2RL_GATHEREDDIR/messages
+      cp -r /var/log/messages* $EC2RL_GATHEREDDIR/messages || true
+      echo "I have attempted to copy the /var/log/messages* files to ${EC2RL_GATHEREDDIR}/messages"
+  elif [ -r /var/log/syslog ]; then
+      mkdir $EC2RL_GATHEREDDIR/messages
+      cp -r /var/log/syslog* $EC2RL_GATHEREDDIR/messages || true
+      echo "I have attempted to copy the /var/log/syslog* files to ${EC2RL_GATHEREDDIR}/messages"
   else
       echo "No /var/log/messages* or /var/log/syslog* files available or permission denied"
   fi

--- a/mod.d/mysqldlog.yaml
+++ b/mod.d/mysqldlog.yaml
@@ -39,13 +39,12 @@ content: !!str |
 
   echo "I will gather /var/log/mysqld.log* files from this machine"
 
-  if [ -r /var/log/mysqld.log ]
-      then
-          mkdir $EC2RL_GATHEREDDIR/mysqldlog
-          cp -r /var/log/mysqld.log* $EC2RL_GATHEREDDIR/mysqldlog
-          echo "I have attempted to copy the /var/log/mysqld.log* files to ${EC2RL_GATHEREDDIR}/mysqldlog"
-      else
-          echo "No /var/log/mysqld.log* file available or permission denied"
+  if [ -r /var/log/mysqld.log ]; then
+      mkdir $EC2RL_GATHEREDDIR/mysqldlog
+      cp -r /var/log/mysqld.log* $EC2RL_GATHEREDDIR/mysqldlog
+      echo "I have attempted to copy the /var/log/mysqld.log* files to ${EC2RL_GATHEREDDIR}/mysqldlog"
+  else
+      echo "No /var/log/mysqld.log* file available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False

--- a/mod.d/nginxlogs.yaml
+++ b/mod.d/nginxlogs.yaml
@@ -17,9 +17,9 @@
 name: !!str nginxlogs
 path: !!str
 version: !!str 1.0
-title: !!str Gather up /var/log/nginx/* log files
+title: !!str Gather /var/log/nginx/* log files
 helptext: !!str |
-  Gather up /var/log/nginx/* log files. This assumes default paths.
+  Gather /var/log/nginx/* log files. This assumes default paths.
 placement: !!str run
 package: 
   - !!str
@@ -39,13 +39,12 @@ content: !!str |
 
   echo "I will gather /var/log/nginx/* log files from this machine"
 
-  if [ -r /var/log/nginx ]
-      then
-          mkdir $EC2RL_GATHEREDDIR/nginxlogs
-          cp -r /var/log/nginx/* $EC2RL_GATHEREDDIR/nginxlogs || true
-          echo "I have attempted to copy the /var/log/nginx/* log files to ${EC2RL_GATHEREDDIR}/nginxlogs"
-      else
-          echo "No /var/log/nginx/* log files available or permission denied"
+  if [ -r /var/log/nginx ]; then
+      mkdir $EC2RL_GATHEREDDIR/nginxlogs
+      cp -r /var/log/nginx/* $EC2RL_GATHEREDDIR/nginxlogs || true
+      echo "I have attempted to copy the /var/log/nginx/* log files to ${EC2RL_GATHEREDDIR}/nginxlogs"
+  else
+      echo "No /var/log/nginx/* log files available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False

--- a/mod.d/nsswitch.yaml
+++ b/mod.d/nsswitch.yaml
@@ -17,9 +17,9 @@
 name: !!str nsswitch
 path: !!str
 version: !!str 1.0
-title: !!str Gather up /etc/nsswitch.conf file
+title: !!str Gather /etc/nsswitch.conf file
 helptext: !!str |
-  Gather up /etc/nsswitch.conf file
+  Gather /etc/nsswitch.conf file
 placement: !!str run
 package: 
   - !!str
@@ -39,13 +39,12 @@ content: !!str |
 
   echo "I will gather the /etc/nsswitch.conf file from this machine"
 
-  if [ -r /etc/nsswitch.conf ]
-      then
-          mkdir $EC2RL_GATHEREDDIR/nsswitch
-          cp /etc/nsswitch.conf $EC2RL_GATHEREDDIR/nsswitch/ || true
-          echo "I have attempted to copy the /etc/nsswitch.conf file to ${EC2RL_GATHEREDDIR}/nsswitch"
-      else
-          echo "No /etc/nsswitch.conf available or permission denied"
+  if [ -r /etc/nsswitch.conf ]; then
+      mkdir $EC2RL_GATHEREDDIR/nsswitch
+      cp /etc/nsswitch.conf $EC2RL_GATHEREDDIR/nsswitch/ || true
+      echo "I have attempted to copy the /etc/nsswitch.conf file to ${EC2RL_GATHEREDDIR}/nsswitch"
+  else
+      echo "No /etc/nsswitch.conf available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False

--- a/mod.d/resolvconf.yaml
+++ b/mod.d/resolvconf.yaml
@@ -39,13 +39,12 @@ content: !!str |
 
   echo "I will gather the /etc/resolv.conf filefile from this machine"
 
-  if [ -r /etc/resolv.conf ]
-      then
-          mkdir $EC2RL_GATHEREDDIR/resolvconf
-          cp /etc/resolv.conf $EC2RL_GATHEREDDIR/resolvconf/ || true
-          echo "I have attempted to copy the /etc/resolv.conf file to ${EC2RL_GATHEREDDIR}/resolvconf"
-      else
-          echo "No /etc/resolv.conf available or permission denied"
+  if [ -r /etc/resolv.conf ]; then
+      mkdir $EC2RL_GATHEREDDIR/resolvconf
+      cp /etc/resolv.conf $EC2RL_GATHEREDDIR/resolvconf/ || true
+      echo "I have attempted to copy the /etc/resolv.conf file to ${EC2RL_GATHEREDDIR}/resolvconf"
+  else
+      echo "No /etc/resolv.conf available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False

--- a/mod.d/sarhistory.yaml
+++ b/mod.d/sarhistory.yaml
@@ -17,9 +17,9 @@
 name: !!str sarhistory
 path: !!str
 version: !!str 1.0
-title: !!str Gather up /var/log/sa (sar) history files
+title: !!str Gather /var/log/sa (sar) history files
 helptext: !!str |
-  Gather up /var/log/sa (sar) history files
+  Gather /var/log/sa (sar) history files
   sar is provided by the sysstat package
 placement: !!str run
 package: 
@@ -40,16 +40,14 @@ content: !!str |
 
   echo "I will gather /var/log/sa (sar) history files from this machine"
 
-  if [ -r /var/log/sa ]
-      then
-          mkdir $EC2RL_GATHEREDDIR/sarhistory
-          cp -r /var/log/sa/* $EC2RL_GATHEREDDIR/sarhistory || true
-          echo "I have attempted to copy the /var/log/sa history files to ${EC2RL_GATHEREDDIR}/sarhistory"
-  elif [ -r /var/log/sysstat ]
-      then
-          mkdir $EC2RL_GATHEREDDIR/sarhistory
-          cp -r /var/log/sysstat/* $EC2RL_GATHEREDDIR/sarhistory || true
-          echo "I have attempted to copy the /var/log/sysstat history files to ${EC2RL_GATHEREDDIR}/sarhistory"
+  if [ -r /var/log/sa ]; then
+      mkdir $EC2RL_GATHEREDDIR/sarhistory
+      cp -r /var/log/sa/* $EC2RL_GATHEREDDIR/sarhistory || true
+      echo "I have attempted to copy the /var/log/sa history files to ${EC2RL_GATHEREDDIR}/sarhistory"
+  elif [ -r /var/log/sysstat ]; then
+      mkdir $EC2RL_GATHEREDDIR/sarhistory
+      cp -r /var/log/sysstat/* $EC2RL_GATHEREDDIR/sarhistory || true
+      echo "I have attempted to copy the /var/log/sysstat history files to ${EC2RL_GATHEREDDIR}/sarhistory"
   else
       echo "No /var/log/sa or /var/log/sysstat history files available or permission denied"
   fi

--- a/mod.d/yumlog.yaml
+++ b/mod.d/yumlog.yaml
@@ -17,9 +17,9 @@
 name: !!str yumlog
 path: !!str
 version: !!str 1.0
-title: !!str Gather up /var/log/yum.log file
+title: !!str Gather /var/log/yum.log file
 helptext: !!str |
-  Gather up /var/log/yum.log file
+  Gather /var/log/yum.log file
 placement: !!str run
 package: 
   - !!str
@@ -39,13 +39,12 @@ content: !!str |
 
   echo "I will gather the /var/log/yum.log file from this machine"
 
-  if [ -r /var/log/yum.log ]
-      then
-          mkdir $EC2RL_GATHEREDDIR/yumlog
-          cp /var/log/yum.log $EC2RL_GATHEREDDIR/yumlog || true
-          echo "I have attempted to copy the /var/logyum.log file to ${EC2RL_GATHEREDDIR}/yumlog"
-      else
-          echo "No /var/log/yum.log available or permission denied"
+  if [ -r /var/log/yum.log ]; then
+      mkdir $EC2RL_GATHEREDDIR/yumlog
+      cp /var/log/yum.log $EC2RL_GATHEREDDIR/yumlog || true
+      echo "I have attempted to copy the /var/logyum.log file to ${EC2RL_GATHEREDDIR}/yumlog"
+  else
+      echo "No /var/log/yum.log available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False

--- a/mod.d/zypperlog.yaml
+++ b/mod.d/zypperlog.yaml
@@ -39,15 +39,13 @@ content: !!str |
 
   echo "I will gather /var/log/zypp and zypper.log log files from this machine"
 
-  if [[ -r /var/log/zypp && -r /var/log/zypper.log ]]
-      then
-          mkdir $EC2RL_GATHEREDDIR/zypperlog
-          cp -r /var/log/zypp/* $EC2RL_GATHEREDDIR/zypperlog || true
-          cp /var/log/zypper.log* $EC2RL_GATHEREDDIR/zypperlog || true
-          echo "I have attempted to copy the /var/log/zypp and zypper.log  log files to ${EC2RL_GATHEREDDIR}/zypperlog"
-
-      else
-          echo "No /var/log/zypp or zypper.log log files available or permission denied"
+  if [[ -r /var/log/zypp ]]; then
+      mkdir $EC2RL_GATHEREDDIR/zypperlog
+      cp -r /var/log/zypp/* $EC2RL_GATHEREDDIR/zypperlog || true
+      cp /var/log/zypper.log* $EC2RL_GATHEREDDIR/zypperlog || true
+      echo "I have attempted to copy the /var/log/zypp and zypper.log  log files to ${EC2RL_GATHEREDDIR}/zypperlog"
+  else
+      echo "No /var/log/zypp or zypper.log log files available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False


### PR DESCRIPTION
Update all gather modules to new verbiage 'Gather vs collect or gather up' and fix indentation.

Also fix another  edge case with zypperlog module that escaped me the first time. (My previous fix would resolve it not copying over logrotated files, but did not resolve another bug: If there were ONLY logrotated zypper files, it would not attempt to copy at all)