### PR TITLE
Refactor Options.cmdline() to better handle CLI args and config files…

### DIFF
--- a/test/configurations/invalid_subcommand.cfg
+++ b/test/configurations/invalid_subcommand.cfg
@@ -1,0 +1,2 @@
+[Global]
+subcommand = not_a_valid_subcommand

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -144,6 +144,18 @@ class TestOptions(unittest.TestCase):
         self.assertEqual(self.options.global_args["asdf"], "1234")
         self.assertEqual(self.options.per_module_args["arpcache"]["efgh"], "5678")
 
+    def test_options_load_good_config_no_subcommand(self):
+        """
+        Test that loading a good configuration file with no subcommand and no subcommand provided via CLI args
+        results in an unset subcommand.
+        """
+        configuration_path = os.path.join(self.callpath, "test/configurations/configuration.cfg")
+        sys.argv = ["ec2rl", "--config-file={}".format(configuration_path)]
+        self.options = ec2rlcore.options.Options(subcommands=self.__subcommands)
+        self.assertEqual(self.options.global_args["asdf"], "1234")
+        self.assertEqual(self.options.per_module_args["arpcache"]["efgh"], "5678")
+        self.assertFalse(self.options.subcommand)
+
     def test_options_load_good_config_empty_section(self):
         """Test that loading a configuration file with an empty section doesn't create a corresponding dict key."""
         configuration_path = os.path.join(self.callpath, "test/configurations/empty_section_config.cfg")
@@ -164,6 +176,16 @@ class TestOptions(unittest.TestCase):
         configuration_path = os.path.join(self.callpath, "test/configurations/junk_config.cfg")
         sys.argv = ["ec2rl", "run", "--config-file={}".format(configuration_path)]
         with self.assertRaises(ec2rlcore.options.OptionsInvalidConfigurationFile):
+            self.options = ec2rlcore.options.Options(subcommands=self.__subcommands)
+
+    def test_options_load_invalid_subcommand(self):
+        """
+        Test that attempting to load configuration with an unsupport subcommand raises
+        OptionsInvalidSubcommandConfigFileError.
+        """
+        configuration_path = os.path.join(self.callpath, "test/configurations/invalid_subcommand.cfg")
+        sys.argv = ["ec2rl", "run", "--config-file={}".format(configuration_path)]
+        with self.assertRaises(ec2rlcore.options.OptionsInvalidSubcommandConfigFileError):
             self.options = ec2rlcore.options.Options(subcommands=self.__subcommands)
 
     def test_options_load_missing_config(self):


### PR DESCRIPTION
… when both are present.

Known args, such as --config-file and --no, that are unset are now removed from the arg dict before it is processed so they are not written to a config file later.
Configuration file level options take precedence over command line args.
config_file is no longer written to the configuration file itself. This served no purpose and it was not clear to the user how config_file in both the file and the command line arguments interacted.
It is now possible to specify the subcommand from the config file without specifying it via the command line.