### PR TITLE
Add date module to get system date including timezone for referencing…

### DIFF
--- a/mod.d/date.yaml
+++ b/mod.d/date.yaml
@@ -1,0 +1,50 @@
+# Copyright 2016-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+--- !ec2rlcore.module.Module
+# Module document. Translates directly into an almost-complete Module object
+name: !!str date
+path: !!str
+version: !!str 1.0
+title: !!str Collect output from date to get system time and timezone
+helptext: !!str |
+  Collect output from date to get system time and timezone
+placement: !!str run
+package: 
+  - !!str
+language: !!str bash
+content: !!str |
+  #!/bin/bash
+  error_trap()
+  {
+      printf "%0.s=" {1..80}
+      echo -e "\nERROR:	"$BASH_COMMAND" exited with an error on line ${BASH_LINENO[0]}"
+      exit 0
+  }
+  trap error_trap ERR
+
+  echo "I will collect date output from this $EC2RL_DISTRO box."
+
+  date
+constraint:
+  requires_ec2: !!str False
+  domain: !!str os
+  class: !!str collect
+  distro: !!str alami ubuntu rhel suse
+  required: !!str
+  optional: !!str
+  software: !!str date
+  sudo: !!str False
+  perfimpact: !!str False
+  parallelexclusive: !!str


### PR DESCRIPTION
While our logdir timestamps are in UTC, we do not necessarily know what timezone instance logs, etc, are in. Adding a module that gets date output does this for us.

Potential drawback: If the module is excluded, we do not have this information. Might want to look at doing this as part of the framework in the future.