### PR TITLE
Only split _callp if it a file path.

### DIFF
--- a/test/test_console_out.py
+++ b/test/test_console_out.py
@@ -45,7 +45,10 @@ class TestConsoleOut(unittest.TestCase):
     _callp = sys.argv[0]
     if not os.path.isabs(_callp):
         _callp = os.path.abspath(_callp)
-    callpath = os.path.split(_callp)[0]
+    if os.path.isdir(_callp):
+        callpath = _callp
+    else:
+        callpath = os.path.split(_callp)[0]
 
     def setUp(self):
         """Setup the module that will be used for the tests."""

--- a/test/test_logutil.py
+++ b/test/test_logutil.py
@@ -34,7 +34,10 @@ class TestLogUtil(unittest.TestCase):
     _callp = sys.argv[0]
     if not os.path.isabs(_callp):
         _callp = os.path.abspath(_callp)
-    callpath = os.path.split(_callp)[0]
+    if os.path.isdir(_callp):
+        callpath = _callp
+    else:
+        callpath = os.path.split(_callp)[0]
 
     log_path = module_path = os.path.join(callpath, "test/test.log")
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -70,7 +70,10 @@ class TestMain(unittest.TestCase):
     _callp = sys.argv[0]
     if not os.path.isabs(_callp):
         _callp = os.path.abspath(_callp)
-    callpath = os.path.split(_callp)[0]
+    if os.path.isdir(_callp):
+        callpath = _callp
+    else:
+        callpath = os.path.split(_callp)[0]
     ec2rl = None
     PROGRAM_VERSION="1.0.0"
 

--- a/test/test_menu.py
+++ b/test/test_menu.py
@@ -34,7 +34,10 @@ class TestMenu(unittest.TestCase):
     _callp = sys.argv[0]
     if not os.path.isabs(_callp):
         _callp = os.path.abspath(_callp)
-    callpath = os.path.split(_callp)[0]
+    if os.path.isdir(_callp):
+        callpath = _callp
+    else:
+        callpath = os.path.split(_callp)[0]
 
     def setUp(self):
         """Default Options."""

--- a/test/test_menu_config.py
+++ b/test/test_menu_config.py
@@ -36,7 +36,10 @@ class TestMenuConfig(unittest.TestCase):
     _callp = sys.argv[0]
     if not os.path.isabs(_callp):
         _callp = os.path.abspath(_callp)
-    callpath = os.path.split(_callp)[0]
+    if os.path.isdir(_callp):
+        callpath = _callp
+    else:
+        callpath = os.path.split(_callp)[0]
 
     module_path = os.path.join(callpath, "test/modules/mod.d")
     modules = ec2rlcore.moduledir.ModuleDir(module_path)

--- a/test/test_menu_item.py
+++ b/test/test_menu_item.py
@@ -28,7 +28,10 @@ class TestMenuItem(unittest.TestCase):
     _callp = sys.argv[0]
     if not os.path.isabs(_callp):
         _callp = os.path.abspath(_callp)
-    callpath = os.path.split(_callp)[0]
+    if os.path.isdir(_callp):
+        callpath = _callp
+    else:
+        callpath = os.path.split(_callp)[0]
 
     def setUp(self):
         """Instantiate one of each type of menu object."""

--- a/test/test_menu_textpad_mod.py
+++ b/test/test_menu_textpad_mod.py
@@ -29,7 +29,10 @@ class TestMenuTextpadMod(unittest.TestCase):
     _callp = sys.argv[0]
     if not os.path.isabs(_callp):
         _callp = os.path.abspath(_callp)
-    callpath = os.path.split(_callp)[0]
+    if os.path.isdir(_callp):
+        callpath = _callp
+    else:
+        callpath = os.path.split(_callp)[0]
 
     def setUp(self):
         """Default Options."""

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -44,7 +44,10 @@ class TestModule(unittest.TestCase):
     _callp = sys.argv[0]
     if not os.path.isabs(_callp):
         _callp = os.path.abspath(_callp)
-    callpath = os.path.split(_callp)[0]
+    if os.path.isdir(_callp):
+        callpath = _callp
+    else:
+        callpath = os.path.split(_callp)[0]
 
     def setUp(self):
         self.output = StringIO()

--- a/test/test_moduledir.py
+++ b/test/test_moduledir.py
@@ -47,7 +47,10 @@ class TestModuleDir(unittest.TestCase):
     _callp = sys.argv[0]
     if not os.path.isabs(_callp):
         _callp = os.path.abspath(_callp)
-    callpath = os.path.split(_callp)[0]
+    if os.path.isdir(_callp):
+        callpath = _callp
+    else:
+        callpath = os.path.split(_callp)[0]
 
     def setUp(self):
         self.output = StringIO()

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -39,7 +39,10 @@ class TestOptions(unittest.TestCase):
     _callp = sys.argv[0]
     if not os.path.isabs(_callp):
         _callp = os.path.abspath(_callp)
-    callpath = os.path.split(_callp)[0]
+    if os.path.isdir(_callp):
+        callpath = _callp
+    else:
+        callpath = os.path.split(_callp)[0]
 
     def setUp(self):
         """Setup the default options"""

--- a/test/test_paralleldiagnostics.py
+++ b/test/test_paralleldiagnostics.py
@@ -63,7 +63,10 @@ class TestParallelDiagnostics(unittest.TestCase):
     _callp = sys.argv[0]
     if not os.path.isabs(_callp):
         _callp = os.path.abspath(_callp)
-    callpath = os.path.split(_callp)[0]
+    if os.path.isdir(_callp):
+        callpath = _callp
+    else:
+        callpath = os.path.split(_callp)[0]
 
     logdir = os.path.join(callpath, "test")
 


### PR DESCRIPTION
When running unit tests programmatically, 'callpath' ends up being the equivalent of '../' which breaks pathing when loading modules, etc. This change tries to ensure that callpath is the full directory path and only a filename is chopped off the path.