### PR TITLE
Lock in moto version 0.4.31.

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -14,6 +14,6 @@ configparser >= 3.5.0; python_version == '2.7'
 contextlib2 >= 0.5.4; python_version < '3.4'
 coverage >= 4.3.4
 mock >= 1.3.0 ; python_version >= '3.3'
-moto >= 0.4.31
+moto == 0.4.31
 responses >= 0.5.1
 requests >= 2.9.0


### PR DESCRIPTION
moto 1.0.0+ is backwards incompatible and several tests that rely on moto mocking the availability zone metadata no longer execute properly. Instead, these tests now raise NotImplementedError. Version 0.4.31 is known to work with our tests so until the issues are addressed, version 1.0.0+ cannot be used.