### PR TITLE
Add absolute path of the Python interpreter binary to the bug-report …

### DIFF
--- a/ec2rlcore/main.py
+++ b/ec2rlcore/main.py
@@ -680,8 +680,8 @@ class Main(object):
     def bug_report(self):
         """Print version information relevant for inclusion in a bug report and return True."""
         print("ec2rl {}".format(self.PROGRAM_VERSION))
-        print("Python {}".format(platform.python_version()))
-        print("{}, kernel {}".format(ec2rlcore.prediag.get_distro(), platform.release()))
+        print("{}, {}".format(ec2rlcore.prediag.get_distro(), platform.release()))
+        print("Python {}, {}".format(platform.python_version(), sys.executable))
         return True
 
     def upload(self):

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -545,14 +545,14 @@ class TestMain(unittest.TestCase):
         with contextlib.redirect_stdout(self.output):
             self.assertTrue(self.ec2rl.bug_report())
 
-        # Check that the length of the bugreport message is of the minimum expected length
-        # This is very variable so the comparison is against:
-        # 22, the hardcoded character count
-        # + the length of the version number
-        # + 5 characters for the Python version (may be 6 though)
-        # + 5 characters for kernel version (this is the absolute minimum e.g. 4.4.0 but will likely be many more)
-        # + 4 characters for distro with "suse" being the shortest string returned by prediag.get_distro()
-        self.assertTrue(len(self.output.getvalue()) >= 22 + len(self.PROGRAM_VERSION) + 5 + 5 + 4)
+        # Example output:
+        # ec2rl 1.0.0
+        # ubuntu, 4.4.0-83-generic
+        # Python 3.5.2, /usr/bin/python3
+        regex_str = r"^ec2rl\ [0-9]+\.[0-9]+\.[0-9]+.*\n(ubuntu|suse|rhel|alami),\ [0-9]+\.[0-9]+\.[0-9]+.*\n" \
+                    r"Python\ [0-9]+\.[0-9]+\.[0-9]+.*,\ /.*\n$"
+
+        self.assertTrue(re.match(regex_str, self.output.getvalue()))
 
     def test_main__setup_environ(self):
         """Test that environment variables are setup as expected."""


### PR DESCRIPTION
…subcommand.

Adding this path to the bug-report output enables a user to differentiate a binary build from the Python-interpreted build with a reasonable degree of certainty. Additionally, the absolute path can provide insight into whether the Python interpreter binary is part of a third party Python installation (installed from outside the operating system's package manager).