### PR TITLE
Convert tcprecycle and arpcache modules to python

### DIFF
--- a/docs/modules/tcprecycle.md
+++ b/docs/modules/tcprecycle.md
@@ -41,11 +41,11 @@ This setting can be disabled on a temporary or permanent basis.
 To disable it temporarily:
 
 ```commandline
-sudo sysctl -w inet.ipv4.tcp_tw_recycle=0
+sudo sysctl -w net.ipv4.tcp_tw_recycle=0
 ```
 
 To disable it permanently
 
 ```commandline
-echo 'inet.ipv4.tcp_tw_recycle=0' | sudo tee /etc/sysctl.conf
+echo 'net.ipv4.tcp_tw_recycle=0' | sudo tee /etc/sysctl.conf
 ```

--- a/mod.d/arpcache.yaml
+++ b/mod.d/arpcache.yaml
@@ -33,7 +33,7 @@ content: !!str |
   try:
       print("Determining if agressive ARP caching is is enabled")
       arpstatus = subprocess.check_output(["sysctl", "net.ipv4.neigh.default.gc_thresh1"]).decode("utf-8")
-      if re.search("0", arpstatus):
+      if re.match(r"net.ipv4.neigh.default.gc_thresh1\ =\ 0", arpstatus):
           arp_success = True
       else:
           arp_success = False
@@ -52,7 +52,6 @@ content: !!str |
       print("[WARN] module generated an exception and exited abnormally. "
             "Review the logs to determine the cause of the issue.")
       sys.exit(0)
-
 constraint:
   requires_ec2: !!str False
   domain: !!str net

--- a/mod.d/arpcache.yaml
+++ b/mod.d/arpcache.yaml
@@ -16,7 +16,7 @@
 # Module document. Translates directly into an almost-complete Module object
 name: !!str arpcache
 path: !!str
-version: !!str 1.0
+version: !!str 2.0
 title: !!str Determines if aggressive arp caching is enabled
 helptext: !!str |
   Determines if aggressive arp caching is enabled.
@@ -24,33 +24,35 @@ helptext: !!str |
 placement: !!str run
 package: 
   - !!str
-language: !!str bash
+language: !!str python
 content: !!str |
-  #!/bin/bash
-  error_trap()
-  {
-      printf "%0.s=" {1..80}
-      echo -e "\nERROR:	"$BASH_COMMAND" exited with an error on line ${BASH_LINENO[0]}"
-      exit 0
-  }
-  trap error_trap ERR
+  from __future__ import print_function
+  import re
+  import subprocess
 
-  # read-in shared function
-  source functions.bash
+  try:
+      print("Determining if agressive ARP caching is is enabled")
+      arpstatus = subprocess.check_output(["sysctl", "net.ipv4.neigh.default.gc_thresh1"]).decode("utf-8")
+      if re.search("0", arpstatus):
+          arp_success = True
+      else:
+          arp_success = False
+      if arp_success:
+          print("[SUCCESS] Aggressive arp caching is disabled.")
+      else:
+          print("[FAILURE] You have aggressive arp caching enabled. "
+                "This can cause issues communicating with instances in the same subnet")
+          print("-- To disable, you can run 'sudo sysctl -w net.ipv4.neigh.default.gc_thresh1=0'")
+          print("-- To disable it from re-occuring on next boot, you can run "
+                "'echo 'net.ipv4.neigh.default.gc_thresh1 = 0' | sudo tee /etc/sysctl.d/55-arp-gc_thresh1.conf'")
+      print("Please see https://github.com/awslabs/aws-ec2rescue-linux/blob/master/docs/modules/arpcache.md"
+          " for further details")
+  except Exception as ex:
+      print(ex)
+      print("[WARN] module generated an exception and exited abnormally. "
+            "Review the logs to determine the cause of the issue.")
+      sys.exit(0)
 
-  echo "Determining if aggressive arp caching is enabled"
-
-  if /sbin/sysctl net.ipv4.neigh.default | grep 'thresh1 = 1'
-      then
-          echo "[FAILURE] You have aggressive arp caching enabled."
-          echo "-- This can cause issues communicating with instances in the same subnet."
-          echo "-- To disable, you can run 'sudo sysctl -w net.ipv4.neigh.default.gc_thresh1=0'"
-          echo "-- To prevent it from re-occuring on next boot, you can run:"
-          echo "--  echo 'net.ipv4.neigh.default.gc_thresh1 = 0' | sudo tee /etc/sysctl.d/55-arp-gc_thresh1.conf"
-      else
-          echo "[SUCCESS] Aggressive arp caching is disabled."
-  fi
-  echo "Please see https://github.com/awslabs/aws-ec2rescue-linux/blob/master/docs/modules/arpcache.md for further details"
 constraint:
   requires_ec2: !!str False
   domain: !!str net

--- a/mod.d/arpcache.yaml
+++ b/mod.d/arpcache.yaml
@@ -34,11 +34,7 @@ content: !!str |
       print("Determining if agressive ARP caching is is enabled")
       arpstatus = subprocess.check_output(["sysctl", "net.ipv4.neigh.default.gc_thresh1"]).decode("utf-8")
       if re.match(r"net.ipv4.neigh.default.gc_thresh1\ =\ 0", arpstatus):
-          arp_success = True
-      else:
-          arp_success = False
-      if arp_success:
-          print("[SUCCESS] Aggressive arp caching is disabled.")
+           print("[SUCCESS] Aggressive arp caching is disabled.")
       else:
           print("[FAILURE] You have aggressive arp caching enabled. "
                 "This can cause issues communicating with instances in the same subnet")

--- a/mod.d/tcprecycle.yaml
+++ b/mod.d/tcprecycle.yaml
@@ -16,7 +16,7 @@
 # Module document. Translates directly into an almost-complete Module object
 name: !!str tcprecycle
 path: !!str
-version: !!str 1.0
+version: !!str 2.0
 title: !!str Determines if aggressive TCP recycling is enabled
 helptext: !!str |
   Determines if aggressive TCP recycling is enabled.
@@ -24,31 +24,34 @@ helptext: !!str |
 placement: !!str run
 package: 
   - !!str
-language: !!str bash
+language: !!str python
 content: !!str |
-  #!/bin/bash
-  error_trap()
-  {
-      printf "%0.s=" {1..80}
-      echo -e "\nERROR:	"$BASH_COMMAND" exited with an error on line ${BASH_LINENO[0]}"
-      exit 0
-  }
-  trap error_trap ERR
- 
-  # read-in shared function
-  source functions.bash
- 
-  echo "Determining if TCP recycle is enabled"
- 
-  if sysctl net.ipv4.tcp_tw_recycle |grep "= 1"
-      then
-          echo "[FAILURE] You have aggressive TCP connection recycling enabled. This may cause networking issues when source TCP connections originate from a NAT device."
-          echo "-- To disable, you can run sudo sysctl -w inet.ipv4.tcp_tw_recycle=0"
-          echo "-- To disable it from re-occuring on next boot, you can run'echo 'inet.ipv4.tcp_tw_recycle= 0' | sudo tee /etc/sysctl.conf'"
-      else
-          echo "[SUCCESS] Aggressive TCP recycling is disabled."
-  fi
-  echo "Please see https://github.com/awslabs/aws-ec2rescue-linux/blob/master/docs/modules/tcprecycle.md for further details"
+  from __future__ import print_function
+  import re
+  import subprocess
+
+  try:
+      print("Determining if TCP recycle is enabled")
+      recyclestatus = subprocess.check_output(["sysctl", "net.ipv4.tcp_tw_recycle"]).decode("utf-8")
+      if re.search("0", recyclestatus):
+          recycle_success = True
+      else:
+          recycle_success = False
+      if recycle_success:
+          print("[SUCCESS] Aggressive TCP recycling is disabled.")
+      else:
+          print("[FAILURE] You have aggressive TCP connection recycling enabled. "
+                "This may cause networking issues when source TCP connections originate from a NAT device.")
+          print("-- To disable, you can run sudo sysctl -w inet.ipv4.tcp_tw_recycle=0")
+          print("-- To disable it from re-occuring on next boot, you can run'echo 'inet.ipv4.tcp_tw_recycle= 0' |"
+                " sudo tee /etc/sysctl.conf'")
+      print("Please see https://github.com/awslabs/aws-ec2rescue-linux/blob/master/docs/modules/tcprecycle.md"
+          " for further details")
+  except Exception as ex:
+      print(ex)
+      print("[WARN] module generated an exception and exited abnormally. "
+            "Review the logs to determine the cause of the issue.")
+      sys.exit(0)
 constraint:
   requires_ec2: !!str False
   domain: !!str net

--- a/mod.d/tcprecycle.yaml
+++ b/mod.d/tcprecycle.yaml
@@ -42,8 +42,8 @@ content: !!str |
       else:
           print("[FAILURE] You have aggressive TCP connection recycling enabled. "
                 "This may cause networking issues when source TCP connections originate from a NAT device.")
-          print("-- To disable, you can run sudo sysctl -w net.ipv4.tcp_tw_recycle=0")
-          print("-- To disable it from re-occuring on next boot, you can run'echo 'net.ipv4.tcp_tw_recycle= 0' |"
+          print("-- To disable, you can run 'sudo sysctl -w net.ipv4.tcp_tw_recycle=0'")
+          print("-- To disable it from re-occuring on next boot, you can run 'echo 'net.ipv4.tcp_tw_recycle= 0' |"
                 " sudo tee /etc/sysctl.conf'")
       print("Please see https://github.com/awslabs/aws-ec2rescue-linux/blob/master/docs/modules/tcprecycle.md"
           " for further details")

--- a/mod.d/tcprecycle.yaml
+++ b/mod.d/tcprecycle.yaml
@@ -34,10 +34,6 @@ content: !!str |
       print("Determining if TCP recycle is enabled")
       recyclestatus = subprocess.check_output(["sysctl", "net.ipv4.tcp_tw_recycle"]).decode("utf-8")
       if re.match(r"net.ipv4.tcp_tw_recycle\ =\ 0", recyclestatus):
-          recycle_success = True
-      else:
-          recycle_success = False
-      if recycle_success:
           print("[SUCCESS] Aggressive TCP recycling is disabled.")
       else:
           print("[FAILURE] You have aggressive TCP connection recycling enabled. "

--- a/mod.d/tcprecycle.yaml
+++ b/mod.d/tcprecycle.yaml
@@ -33,7 +33,7 @@ content: !!str |
   try:
       print("Determining if TCP recycle is enabled")
       recyclestatus = subprocess.check_output(["sysctl", "net.ipv4.tcp_tw_recycle"]).decode("utf-8")
-      if re.search("0", recyclestatus):
+      if re.match(r"net.ipv4.tcp_tw_recycle\ =\ 0", recyclestatus):
           recycle_success = True
       else:
           recycle_success = False

--- a/mod.d/tcprecycle.yaml
+++ b/mod.d/tcprecycle.yaml
@@ -22,7 +22,7 @@ helptext: !!str |
   Determines if aggressive TCP recycling is enabled.
   This may cause networking issues when source TCP connections originate from a NAT device.
 placement: !!str run
-package: 
+package:
   - !!str
 language: !!str python
 content: !!str |
@@ -42,8 +42,8 @@ content: !!str |
       else:
           print("[FAILURE] You have aggressive TCP connection recycling enabled. "
                 "This may cause networking issues when source TCP connections originate from a NAT device.")
-          print("-- To disable, you can run sudo sysctl -w inet.ipv4.tcp_tw_recycle=0")
-          print("-- To disable it from re-occuring on next boot, you can run'echo 'inet.ipv4.tcp_tw_recycle= 0' |"
+          print("-- To disable, you can run sudo sysctl -w net.ipv4.tcp_tw_recycle=0")
+          print("-- To disable it from re-occuring on next boot, you can run'echo 'net.ipv4.tcp_tw_recycle= 0' |"
                 " sudo tee /etc/sysctl.conf'")
       print("Please see https://github.com/awslabs/aws-ec2rescue-linux/blob/master/docs/modules/tcprecycle.md"
           " for further details")


### PR DESCRIPTION
Move from using bash on these to python. Small bugfix in some of the wording in the tcprecycle instructions/documentation.