### PR TITLE
Update mysqldlog module to also gather mariadb logs if it is the flav…

### DIFF
--- a/mod.d/mysqldlog.yaml
+++ b/mod.d/mysqldlog.yaml
@@ -44,7 +44,14 @@ content: !!str |
       cp -r /var/log/mysqld.log* $EC2RL_GATHEREDDIR/mysqldlog
       echo "I have attempted to copy the /var/log/mysqld.log* files to ${EC2RL_GATHEREDDIR}/mysqldlog"
   else
-      echo "No /var/log/mysqld.log* file available or permission denied"
+      echo "No /var/log/mysqld.log* files available or permission denied"
+  fi
+  if [ -r /var/log/mariadb ]; then
+      mkdir -p $EC2RL_GATHEREDDIR/mysqldlog/mariadb
+      cp -r /var/log/mariadb/* $EC2RL_GATHEREDDIR/mysqldlog/mariadb
+      echo "I have attempted to copy the /var/log/maria/* files to ${EC2RL_GATHEREDDIR}/mysqldlog/mariadb"
+  else
+      echo "No /var/log/mariadb/* files available or permission denied"
   fi
 constraint:
   requires_ec2: !!str False

--- a/mod.d/mysqldlog.yaml
+++ b/mod.d/mysqldlog.yaml
@@ -40,8 +40,8 @@ content: !!str |
   echo "I will gather /var/log/mysqld.log* files from this machine"
 
   if [ -r /var/log/mysqld.log ]; then
-      mkdir $EC2RL_GATHEREDDIR/mysqldlog
-      cp -r /var/log/mysqld.log* $EC2RL_GATHEREDDIR/mysqldlog
+      mkdir -p $EC2RL_GATHEREDDIR/mysqldlog/mysql
+      cp -r /var/log/mysqld.log* $EC2RL_GATHEREDDIR/mysqldlog/mysql
       echo "I have attempted to copy the /var/log/mysqld.log* files to ${EC2RL_GATHEREDDIR}/mysqldlog"
   else
       echo "No /var/log/mysqld.log* files available or permission denied"


### PR DESCRIPTION
…or of mysql installed

In some distributions the default location of mariadb (a mysql alternative) is /var/log/maria instead of /var/log/mysqld.log*