### PR TITLE
Disabled journal functionality due to performance concerns

### DIFF
--- a/functions.bash
+++ b/functions.bash
@@ -100,12 +100,13 @@ function logsearch {
         fi
     done
 
-    if which journalctl >/dev/null 2>&1; then
-        if journalctl -ql | grep -v \/grep\ | grep $grepargs "$pattern" >/dev/null 2>&1; then
-            echo -e "Match found in systemd journal"
-            journalctl -ql | grep -v \/grep\ | grep $grepargs "$pattern"
-        fi
-    fi
+    # Disabled journal searching due to performance impact
+    # if which journalctl >/dev/null 2>&1; then
+    #     if journalctl -ql | grep -v \/grep\ | grep $grepargs "$pattern" >/dev/null 2>&1; then
+    #         echo -e "Match found in systemd journal"
+    #         journalctl -ql | grep -v \/grep\ | grep $grepargs "$pattern"
+    #     fi
+    # fi
 }
 
 ##

--- a/mod.d/journal.yaml
+++ b/mod.d/journal.yaml
@@ -19,7 +19,7 @@ path: !!str
 version: !!str 1.0
 title: !!str Gather journal output
 helptext: !!str |
-  Gather journal output
+  Gather journal output - Temporarily disabled due to performance impact
 placement: !!str run
 package: 
   - !!str
@@ -47,7 +47,7 @@ constraint:
   requires_ec2: !!str False
   domain: !!str os
   class: !!str gather
-  distro: !!str ubuntu rhel suse
+  distro: !!str none
   required: !!str
   optional: !!str
   software: !!str journalctl


### PR DESCRIPTION
In our testing using the system journal can cause unexpectedly long execution times when modules read the journal contents.  Disabled the journal module and disabled journal searching functionality within the shared logsearch bash function.