### PR TITLE
Add module unit and functional test run scripts and directory structure.

### DIFF
--- a/tools/moduletests/__init__.py
+++ b/tools/moduletests/__init__.py
@@ -1,0 +1,26 @@
+# Copyright 2016-2017 Amazon com  Inc  or its affiliates  All Rights Reserved
+#
+# Licensed under the Apache License  Version 2 0 (the "License")  You
+# may not use this file except in compliance with the License  A copy of
+# the License is located at
+#
+#     http //aws amazon com/apache2 0/
+#
+#
+# or in the "license" file accompanying this file  This file is
+# distributed on an "AS IS" BASIS  WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND  either express or implied  See the License for the specific
+# language governing permissions and limitations under the License
+
+"""
+Init for module tests
+
+Functions
+    None
+
+Classes
+    None
+
+Exceptions
+    None
+"""

--- a/tools/moduletests/functional/__init__.py
+++ b/tools/moduletests/functional/__init__.py
@@ -1,0 +1,43 @@
+# Copyright 2016-2017 Amazon com  Inc  or its affiliates  All Rights Reserved
+#
+# Licensed under the Apache License  Version 2 0 (the "License")  You
+# may not use this file except in compliance with the License  A copy of
+# the License is located at
+#
+#     http //aws amazon com/apache2 0/
+#
+#
+# or in the "license" file accompanying this file  This file is
+# distributed on an "AS IS" BASIS  WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND  either express or implied  See the License for the specific
+# language governing permissions and limitations under the License
+
+"""
+Init for module functional tets
+
+Functions
+    None
+
+Classes
+    None
+
+Exceptions
+    None
+"""
+
+from __future__ import print_function
+import sys
+
+if sys.hexversion < 0x3000000:
+    # python2's raw_input() was renamed input() in python3 and python2's input() == eval(input())
+    input = raw_input
+
+print("=" * 120)
+print("Running these functional tests will modify the local filesystem and system configuration ")
+print("Test failures may result in system instability and/or inaccessibility ")
+print("Only run these on a disposable test system!")
+print("=" * 120)
+are_you_sure = input("Are you sure you want to continue? [y/N] ")
+if are_you_sure != "y":
+    print("Functional tests aborted ")
+    sys.exit(1)

--- a/tools/moduletests/src/__init__.py
+++ b/tools/moduletests/src/__init__.py
@@ -13,7 +13,7 @@
 # language governing permissions and limitations under the License.
 
 """
-Init for testing. Disable logging to speed up test execution.
+Init for modules under test.
 
 Functions:
     None

--- a/tools/moduletests/unit/__init__.py
+++ b/tools/moduletests/unit/__init__.py
@@ -13,7 +13,7 @@
 # language governing permissions and limitations under the License.
 
 """
-Init for testing. Disable logging to speed up test execution.
+Init for module unit tests.
 
 Functions:
     None

--- a/tools/run_module_functional_tests.py
+++ b/tools/run_module_functional_tests.py
@@ -1,0 +1,60 @@
+# Copyright 2016-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""
+Run functional tests for modules.
+"""
+from __future__ import print_function
+import os
+import sys
+import unittest
+
+
+def main():
+    # Add the root program directory and the module tests directory to sys.path
+    call_paths = list()
+    split_call_path_list = os.path.abspath(sys.argv[0]).split(os.sep)
+    for file_name in [__file__, "tools"]:
+        if split_call_path_list[-1] == file_name and file_name == "tools":
+            call_paths.append(os.sep.join(split_call_path_list))
+            split_call_path_list = split_call_path_list[0:-1]
+        elif split_call_path_list[-1] == file_name:
+            split_call_path_list = split_call_path_list[0:-1]
+        else:
+            print("Error parsing call path on token {}. Aborting.".format(file_name))
+            sys.exit(1)
+    call_paths.append(os.sep.join(split_call_path_list))
+    for call_path in call_paths:
+        sys.path.insert(0, call_path)
+
+    import ec2rlcore.prediag
+    if not ec2rlcore.prediag.check_root():
+        print("Functional tests must be run as root/with sudo! Aborting.")
+        sys.exit(1)
+    try:
+        import moduletests.functional
+        print("Running tests...")
+        tests = unittest.TestLoader().discover(os.sep.join([os.getcwd(), "moduletests", "functional"]))
+        # Due to the nature of the functional tests, failfast=True is set in order to limit the potential damage to
+        # the system configuration in the event of bugs, test failures, etc.
+        results = unittest.runner.TextTestRunner(failfast=True).run(tests)
+        if not results.wasSuccessful():
+            sys.exit(1)
+    except Exception:
+        print("Caught unhandled exception!")
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/run_module_unit_tests.py
+++ b/tools/run_module_unit_tests.py
@@ -1,0 +1,60 @@
+# Copyright 2016-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""
+Run unit tests for modules.
+"""
+from __future__ import print_function
+import os
+import sys
+import unittest
+
+import coverage
+
+
+def main():
+    # Add the root program directory and the module tests directory to sys.path
+    call_paths = list()
+    split_call_path_list = os.path.abspath(sys.argv[0]).split(os.sep)
+    for file_name in [__file__, "tools"]:
+        if split_call_path_list[-1] == file_name and file_name == "tools":
+            call_paths.append(os.sep.join(split_call_path_list))
+            split_call_path_list = split_call_path_list[0:-1]
+        elif split_call_path_list[-1] == file_name:
+            split_call_path_list = split_call_path_list[0:-1]
+        else:
+            print("Error parsing call path on token {}. Aborting.".format(file_name))
+            sys.exit(1)
+    call_paths.append(os.sep.join(split_call_path_list))
+    for call_path in call_paths:
+        sys.path.insert(0, call_path)
+
+    try:
+        print("Running tests...")
+        code_coverage = coverage.Coverage(branch=True, source=["moduletests/src/"])
+        code_coverage.start()
+        tests = unittest.TestLoader().discover(os.sep.join([os.getcwd(), "moduletests", "unit"]))
+        results = unittest.runner.TextTestRunner().run(tests)
+        if not results.wasSuccessful():
+            sys.exit(1)
+        code_coverage.stop()
+        code_coverage.save()
+        code_coverage.report()
+    except Exception:
+        print("Caught unhandled exception!")
+        raise
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
One item of note: importing moduletests.functional requires manual user confirmation because running functional tests will modify the system configuration. We can change this behavior later if there is a desire to add functional tests to the build pipeline.