### PR TITLE
Add modules that collect lists of installed modules using dpkg and rpm.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 #### Modules
 * [Enhancement] arpcache, arpignore, tcprecycle: standardized detection method to not assume the parameter exists in the running kernel. 
 * [New Module] Added dhclientleases module with remediation support.
-
+* [New Module] Added dpkgpackages module.
+* [New Module] Added rpmpackages module.
 
 #### Testing
 * None

--- a/mod.d/dpkgpackages.yaml
+++ b/mod.d/dpkgpackages.yaml
@@ -1,0 +1,55 @@
+# Copyright 2016-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+--- !ec2rlcore.module.Module
+# Module document. Translates directly into an almost-complete Module object
+name: !!str dpkgpackages
+path: !!str
+version: !!str 1.0
+title: !!str Collect list of installed packages using dpkg -l
+helptext: !!str |
+  Collect list of installed packages using dpkg -l
+placement: !!str run
+package:
+  - !!str
+language: !!str bash
+content: !!str |
+  #!/bin/bash
+  error_trap()
+  {
+      printf "%0.s=" {1..80}
+      echo -e "\nERROR:	"$BASH_COMMAND" exited with an error on line ${BASH_LINENO[0]}"
+      exit 0
+  }
+  trap error_trap ERR
+
+  # read-in shared function
+  source functions.bash
+
+  COMMAND="dpkg -l"
+
+  echo "The following packages are installed per '$COMMAND'"
+
+  $COMMAND
+constraint:
+  requires_ec2: !!str False
+  domain: !!str os
+  class: !!str collect
+  distro: !!str alami alami2 ubuntu rhel suse
+  required: !!str
+  optional: !!str
+  software: !!str dpkg
+  sudo: !!str False
+  perfimpact: !!str False
+  parallelexclusive: !!str

--- a/mod.d/rpmpackages.yaml
+++ b/mod.d/rpmpackages.yaml
@@ -1,0 +1,55 @@
+# Copyright 2016-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+--- !ec2rlcore.module.Module
+# Module document. Translates directly into an almost-complete Module object
+name: !!str rpmpackages
+path: !!str
+version: !!str 1.0
+title: !!str Collect list of installed packages using rpm -qa
+helptext: !!str |
+  Collect list of installed packages using rpm -qa
+placement: !!str run
+package:
+  - !!str
+language: !!str bash
+content: !!str |
+  #!/bin/bash
+  error_trap()
+  {
+      printf "%0.s=" {1..80}
+      echo -e "\nERROR:	"$BASH_COMMAND" exited with an error on line ${BASH_LINENO[0]}"
+      exit 0
+  }
+  trap error_trap ERR
+
+  # read-in shared function
+  source functions.bash
+
+  COMMAND="rpm -qa"
+
+  echo "The following packages are installed per '$COMMAND'"
+
+  $COMMAND
+constraint:
+  requires_ec2: !!str False
+  domain: !!str os
+  class: !!str collect
+  distro: !!str alami alami2 ubuntu rhel suse
+  required: !!str
+  optional: !!str
+  software: !!str rpm
+  sudo: !!str False
+  perfimpact: !!str False
+  parallelexclusive: !!str


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This pair of simple modules capture lists of installed packages on the system. Attached are execution logs and 5-10 lines from each module output log.

[dpkgpackages.log](https://github.com/awslabs/aws-ec2rescue-linux/files/2161058/dpkgpackages.log)
[rpmpackages.log](https://github.com/awslabs/aws-ec2rescue-linux/files/2161059/rpmpackages.log)
