### PR TITLE
Add module to gather logs from an AWS Workspace.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [New Module] Added dhclientleases module with remediation support.
 * [New Module] Added dpkgpackages module.
 * [New Module] Added rpmpackages module.
+* [New Module] Added workspaceslogs module.
 
 #### Testing
 * None

--- a/mod.d/workspaceslogs.yaml
+++ b/mod.d/workspaceslogs.yaml
@@ -1,0 +1,70 @@
+# Copyright 2016-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+--- !ec2rlcore.module.Module
+# Module document. Translates directly into an almost-complete Module object
+name: !!str workspacelogs
+path: !!str
+version: !!str 1.0
+title: !!str Gather AWS Linux Workspace log files
+helptext: !!str |
+  Gather AWS Linux Workspace log files
+placement: !!str run
+package:
+  - !!str
+language: !!str bash
+content: !!str |
+  #!/bin/bash
+  error_trap()
+  {
+      printf "%0.s=" {1..80}
+      echo -e "\nERROR:	"$BASH_COMMAND" exited with an error on line ${BASH_LINENO[0]}"
+      exit 0
+  }
+  trap error_trap ERR
+
+  # read-in shared function
+  source functions.bash
+
+  GATHER_PATH="${EC2RL_GATHEREDDIR}/workspacelogs"
+  if [ ! -d "$GATHER_PATH" ]; then
+      mkdir "$GATHER_PATH"
+  fi
+
+  if [ -d /var/log/skylight ] && [ -r /var/log/skylight/ ]; then
+      echo "I will gather the /var/log/skylight directory from this machine"
+      cp -rv /var/log/skylight/ "$GATHER_PATH" || true
+  else
+      echo "/var/log/skylight not present or permission denied"
+  fi
+
+  echo
+
+  if [ -d /var/log/pcoip-agent/ ] && [ -r /var/log/pcoip-agent/ ]; then
+      echo "I will gather the /var/log/pcoip-agent directory from this machine"
+      cp -rv /var/log/pcoip-agent/ "$GATHER_PATH" || true
+  else
+      echo "/var/log/pcoip-agent/ not present or permission denied"
+  fi
+constraint:
+  requires_ec2: !!str False
+  domain: !!str os
+  class: !!str gather
+  distro: !!str alami2
+  required: !!str
+  optional: !!str
+  software: !!str
+  sudo: !!str True
+  perfimpact: !!str False
+  parallelexclusive: !!str


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Regarding the sudo requirement: the skylight directory and its contents are owned by root and two subdirectories are only readable by the owner. The pcoip-agent directory and its contents are owned by a combination of the pcoip user and root, and the contents only have owner permissions.

Attached is ```find``` output for the log directory which shows the files gathered by the module.

[workspacelogs_files.txt](https://github.com/awslabs/aws-ec2rescue-linux/files/2161477/workspacelogs_files.txt)
