### PR TITLE
Update iproute module, add networkmanagerstatus module

### DIFF
--- a/mod.d/iproute.yaml
+++ b/mod.d/iproute.yaml
@@ -37,9 +37,9 @@ content: !!str |
   # read-in shared function
   source functions.bash
 
-  echo "I will collect ip route show all output from this $EC2RL_DISTRO box."
+  echo "I will collect ip route show table all output from this $EC2RL_DISTRO box."
 
-  ip -s route show all
+  ip route show table all
 constraint:
   requires_ec2: !!str False
   domain: !!str net

--- a/mod.d/networkmanagerstatus.yaml
+++ b/mod.d/networkmanagerstatus.yaml
@@ -1,0 +1,53 @@
+# Copyright 2016-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+--- !ec2rlcore.module.Module
+# Module document. Translates directly into an almost-complete Module object
+name: !!str networkmanagerstatus
+path: !!str
+version: !!str 1.0
+title: !!str Collect output from systemctl status NetworkManager for system analysis
+helptext: !!str |
+  Collect output from systemctl status NetworkManager for system analysis
+placement: !!str run
+package: 
+  - !!str
+language: !!str bash
+content: !!str |
+  #!/bin/bash
+  error_trap()
+  {
+      printf "%0.s=" {1..80}
+      echo -e "\nERROR:	"$BASH_COMMAND" exited with an error on line ${BASH_LINENO[0]}"
+      exit 0
+  }
+  trap error_trap ERR
+
+  # read-in shared function
+  source functions.bash
+
+  echo "I will collect systemctl status NetworkManager from this $EC2RL_DISTRO box."
+
+  systemctl status NetworkManager
+constraint:
+  requires_ec2: !!str False
+  domain: !!str net
+  class: !!str collect
+  distro: !!str alami2 ubuntu rhel suse
+  required: !!str
+  optional: !!str
+  software: !!str NetworkManager
+  sudo: !!str False
+  perfimpact: !!str False
+  parallelexclusive: !!str


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Updated iproute module to show routes from tables other than the primary one

Added networkmanagerstatus module to get the status for 'NetworkManager' - NM is not enabled by default on any of our distros, however, it can be installed and configured on the latest versions on all of them except alami1.