### PR TITLE
Add systemsmanager module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@
 #### Modules
 * [Enhancement] Updated iproute module to collect additional route table details.
 * [Enhancement] Added all supported distros to bcc modules.
-* [New Module] Added kernel page table isolation module
-* [New Module] Added retpoline module
-* [New Module] Added networkmanagerstatus module
+* [New Module] Added kernel page table isolation module.
+* [New Module] Added retpoline module.
+* [New Module] Added networkmanagerstatus module.
+* [New Module] Added systemsmanager module.
 
 #### Testing
 * None

--- a/mod.d/systemsmanager.yaml
+++ b/mod.d/systemsmanager.yaml
@@ -1,0 +1,73 @@
+# Copyright 2016-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+--- !ec2rlcore.module.Module
+# Module document. Translates directly into an almost-complete Module object
+name: !!str systemsmanager
+path: !!str
+version: !!str 1.0
+title: !!str Gather AWS Systems Manager logs and configuration
+helptext: !!str |
+  Gather AWS Systems Manager logs from /var/log/amazon/ssm/ and configuration from /etc/amazon/ssm
+placement: !!str run
+package:
+  - !!str
+language: !!str bash
+content: !!str |
+  #!/bin/bash
+  error_trap()
+  {
+      printf "%0.s=" {1..80}
+      echo -e "\nERROR:	\"$BASH_COMMAND\" exited with an error on line ${BASH_LINENO[0]}"
+      exit 0
+  }
+  trap error_trap ERR
+
+  if command -v ssm-cli > /dev/null; then
+    ssm-cli get-instance-information
+  else
+    echo "ssm-cli not found in PATH. No version information available."
+    echo "PATH = $PATH"
+  fi
+
+  if [[ -r /var/log/amazon/ssm && -d /var/log/amazon/ssm ]] || [[ -r /etc/amazon/ssm && -d /etc/amazon/ssm ]]; then
+    mkdir "$EC2RL_GATHEREDDIR"/systemsmanager
+  fi
+
+  if [[ -r /var/log/amazon/ssm && -d /var/log/amazon/ssm ]]; then
+      # e.g. amazon-ssm-agent.log, AmazonSSMAgent-update.txt
+      find /var/log/amazon/ssm/ -maxdepth 1 \( -name "*.log"  -o -name "*.txt" \) -exec cp -v {} "$EC2RL_GATHEREDDIR"/systemsmanager \;
+  else
+      echo "/var/log/amazon/ssm/ missing or permission denied."
+  fi
+
+  if [[ -r /etc/amazon/ssm/amazon-ssm-agent.json ]]; then
+    cp -v /etc/amazon/ssm/amazon-ssm-agent.json "$EC2RL_GATHEREDDIR"/systemsmanager
+  fi
+  if [[ -r /etc/amazon/ssm/seelog.xml ]]; then
+    cp -v /etc/amazon/ssm/seelog.xml "$EC2RL_GATHEREDDIR"/systemsmanager
+  fi
+constraint:
+  requires_ec2: !!str False
+  domain: !!str os
+  class: !!str gather
+  distro: !!str alami alami2 rhel suse ubuntu
+  required: !!str
+  optional: !!str
+  # The Ubuntu snap package doesn't install the executables into a checkable path (e.g. in PATH) so do not set the
+  # software constraint
+  software: !!str
+  sudo: !!str True
+  perfimpact: !!str False
+  parallelexclusive: !!str


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

I think the only item of note is that the Ubuntu snap package doesn't put the executables (e.g. ssm-cli, amazon-ssm-agent) in $PATH so we can't really use the software constraint for this module.