### PR TITLE
Refactor get_instance_region to utilize identity document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None
 
 #### Framework
-* None
+* [Enhancement] Refactor get_instance_region() to utilize identity document
 
 #### Modules
 * None

--- a/ec2rlcore/awshelpers.py
+++ b/ec2rlcore/awshelpers.py
@@ -46,9 +46,10 @@ def get_instance_region():
         Region (str): Region of the currently running instance
     """
     try:
-        r = requests.get("http://169.254.169.254/latest/meta-data/placement/availability-zone")
+        r = requests.get("http://169.254.169.254/latest/dynamic/instance-identity/document")
         r.raise_for_status()
-        return r.text[:-1]
+        document = r.json()
+        return document['region']
     except requests.exceptions.Timeout:
         raise AWSHelperMetadataTimeout()
     except requests.exceptions.HTTPError as err:

--- a/test/test_awshelpers.py
+++ b/test/test_awshelpers.py
@@ -48,9 +48,15 @@ class TestAwshelpers(unittest.TestCase):
     @responses.activate
     def test_awshelpers_get_volume_ids(self):
         """Test that retrieving the volume ids for the instance works as expected."""
+        document = {'privateIp': '172.16.1.128', 'devpayProductCodes': None, 'marketplaceProductCodes': None,
+                    'version': '2017-09-30', 'availabilityZone': 'us-east-1c', 'instanceId': 'i-deadbeef',
+                    'billingProducts': None, 'instanceType': 'm5.4xlarge', 'kernelId': None, 'ramdiskId': None,
+                    'accountId': '1234567890', 'architecture': 'x86_64', 'imageId': 'ami-deadbeef',
+                    'pendingTime': '2018-09-14T01:58:16Z', 'region': 'us-east-1'}
+
         instanceid = self.setup_ec2()
-        responses.add(responses.GET, "http://169.254.169.254/latest/meta-data/placement/availability-zone",
-                      body="us-east-1a", status=200)
+        responses.add(responses.GET, "http://169.254.169.254/latest/dynamic/instance-identity/document",
+                      json=document, status=200)
         responses.add(responses.GET, "http://169.254.169.254/latest/meta-data/instance-id", body=instanceid,
                       status=200)
 
@@ -59,9 +65,15 @@ class TestAwshelpers(unittest.TestCase):
     @responses.activate
     def test_awshelpers_get_volume_mappings(self):
         """Test that retrieving the volume mappings for the instance works as expected."""
+        document = {'privateIp': '172.16.1.128', 'devpayProductCodes': None, 'marketplaceProductCodes': None,
+                    'version': '2017-09-30', 'availabilityZone': 'us-east-1c', 'instanceId': 'i-deadbeef',
+                    'billingProducts': None, 'instanceType': 'm5.4xlarge', 'kernelId': None, 'ramdiskId': None,
+                    'accountId': '1234567890', 'architecture': 'x86_64', 'imageId': 'ami-deadbeef',
+                    'pendingTime': '2018-09-14T01:58:16Z', 'region': 'us-east-1'}
+
         instanceid = self.setup_ec2()
-        responses.add(responses.GET, "http://169.254.169.254/latest/meta-data/placement/availability-zone",
-                      body="us-east-1a", status=200)
+        responses.add(responses.GET, "http://169.254.169.254/latest/dynamic/instance-identity/document",
+                      json=document, status=200)
         responses.add(responses.GET, "http://169.254.169.254/latest/meta-data/instance-id", body=instanceid,
                       status=200)
 
@@ -70,8 +82,14 @@ class TestAwshelpers(unittest.TestCase):
     @responses.activate
     def test_awshelpers_get_instance_region(self):
         """Test that attempting to retrieve the instance region works as expected."""
-        responses.add(responses.GET, "http://169.254.169.254/latest/meta-data/placement/availability-zone",
-                      body="us-east-1a", status=200)
+        document = {'privateIp': '172.16.1.128', 'devpayProductCodes': None, 'marketplaceProductCodes': None,
+                    'version': '2017-09-30', 'availabilityZone': 'us-east-1c', 'instanceId': 'i-deadbeef',
+                    'billingProducts': None, 'instanceType': 'm5.4xlarge', 'kernelId': None, 'ramdiskId': None,
+                    'accountId': '1234567890', 'architecture': 'x86_64', 'imageId': 'ami-deadbeef',
+                    'pendingTime': '2018-09-14T01:58:16Z', 'region': 'us-east-1'}
+
+        responses.add(responses.GET, "http://169.254.169.254/latest/dynamic/instance-identity/document",
+                      json=document, status=200)
 
         resp = ec2rlcore.awshelpers.get_instance_region()
         self.assertEqual(resp, "us-east-1")
@@ -105,8 +123,14 @@ class TestAwshelpers(unittest.TestCase):
     @responses.activate
     def test_awshelpers_get_instance_region_httperror(self):
         """Test that get_instance_region raises AWSHelperMetadataHTTPError."""
-        responses.add(responses.GET, "http://169.254.169.254/latest/meta-data/placement/availability-zone",
-                      body="us-east-1a", status=404)
+        document = {'privateIp': '172.16.1.128', 'devpayProductCodes': None, 'marketplaceProductCodes': None,
+                    'version': '2017-09-30', 'availabilityZone': 'us-east-1c', 'instanceId': 'i-deadbeef',
+                    'billingProducts': None, 'instanceType': 'm5.4xlarge', 'kernelId': None, 'ramdiskId': None,
+                    'accountId': '1234567890', 'architecture': 'x86_64', 'imageId': 'ami-deadbeef',
+                    'pendingTime': '2018-09-14T01:58:16Z', 'region': 'us-east-1'}
+
+        responses.add(responses.GET, "http://169.254.169.254/latest/dynamic/instance-identity/document",
+                      json=document, status=404)
         with self.assertRaises(ec2rlcore.awshelpers.AWSHelperMetadataHTTPError):
             ec2rlcore.awshelpers.get_instance_region()
 
@@ -135,8 +159,14 @@ class TestAwshelpers(unittest.TestCase):
     @mock.patch("ec2rlcore.awshelpers.boto3.client", side_effect=botocore.exceptions.NoCredentialsError())
     @responses.activate
     def test_awshelpers_no_creds_get_volume_mappings(self, mock_client):
-        responses.add(responses.GET, "http://169.254.169.254/latest/meta-data/placement/availability-zone",
-                      body="us-east-1a", status=200)
+        document = {'privateIp': '172.16.1.128', 'devpayProductCodes': None, 'marketplaceProductCodes': None,
+                    'version': '2017-09-30', 'availabilityZone': 'us-east-1c', 'instanceId': 'i-deadbeef',
+                    'billingProducts': None, 'instanceType': 'm5.4xlarge', 'kernelId': None, 'ramdiskId': None,
+                    'accountId': '1234567890', 'architecture': 'x86_64', 'imageId': 'ami-deadbeef',
+                    'pendingTime': '2018-09-14T01:58:16Z', 'region': 'us-east-1'}
+
+        responses.add(responses.GET, "http://169.254.169.254/latest/dynamic/instance-identity/document",
+                      json=document, status=200)
         responses.add(responses.GET, "http://169.254.169.254/latest/meta-data/instance-id", body="i-deadbeef",
                       status=200)
 
@@ -148,8 +178,14 @@ class TestAwshelpers(unittest.TestCase):
     @mock.patch("ec2rlcore.awshelpers.boto3.client", side_effect=botocore.exceptions.NoCredentialsError())
     @responses.activate
     def test_awshelpers_no_creds_get_volume_id(self, mock_client):
-        responses.add(responses.GET, "http://169.254.169.254/latest/meta-data/placement/availability-zone",
-                      body="us-east-1a", status=200)
+        document = {'privateIp': '172.16.1.128', 'devpayProductCodes': None, 'marketplaceProductCodes': None,
+                    'version': '2017-09-30', 'availabilityZone': 'us-east-1c', 'instanceId': 'i-deadbeef',
+                    'billingProducts': None, 'instanceType': 'm5.4xlarge', 'kernelId': None, 'ramdiskId': None,
+                    'accountId': '1234567890', 'architecture': 'x86_64', 'imageId': 'ami-deadbeef',
+                    'pendingTime': '2018-09-14T01:58:16Z', 'region': 'us-east-1'}
+        
+        responses.add(responses.GET, "http://169.254.169.254/latest/dynamic/instance-identity/document",
+                      json=document, status=200)
         responses.add(responses.GET, "http://169.254.169.254/latest/meta-data/instance-id", body="i-deadbeef",
                       status=200)
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Shortly before we began development of ec2rl, a new instance identity document was added to the EC2 metadata service that includes several details, including the region the instance is running on. I wasn't aware of it when I created the get_instance_region function, and instead had been truncating the AZ specifier in the AZ document to get the region.

This change has the function utilize this identity document to get just the region, rather than the AZ document. This should future proof us in case Outposts or some other change results in this being fragile in the future.
