### PR TITLE
Update EC2 metadata access to support IMDSv2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# EC2 Rescue for Linux v1.1.6
+
+#### General
+* None
+
+#### Framework
+* [Enhancement] Modified get_instance_region() and get_instance_id() to support IMDSv2.
+* [Enhancement] Modified verify_metadata(), get_virt_type() and is_an_instance() to support IMDSv2
+
+#### Modules
+* None
+
+#### Testing
+* None
+
 # EC2 Rescue for Linux v1.1.5
 
 #### General

--- a/ec2rlcore/awshelpers.py
+++ b/ec2rlcore/awshelpers.py
@@ -47,6 +47,18 @@ def get_instance_region():
     """
     try:
         r = requests.get("http://169.254.169.254/latest/dynamic/instance-identity/document")
+        if r.status_code == 401:
+            token=(
+                requests.put(
+                    "http://169.254.169.254/latest/api/token", 
+                    headers={'X-aws-ec2-metadata-token-ttl-seconds': '21600'}, 
+                    verify=False
+                )
+            ).text
+            r = requests.get(
+                "http://169.254.169.254/latest/dynamic/instance-identity/document",
+                headers={'X-aws-ec2-metadata-token': token}
+            )
         r.raise_for_status()
         document = r.json()
         return document['region']
@@ -67,6 +79,18 @@ def get_instance_id():
     """
     try:
         r = requests.get("http://169.254.169.254/latest/meta-data/instance-id")
+        if r.status_code == 401:
+            token=(
+                requests.put(
+                    "http://169.254.169.254/latest/api/token", 
+                    headers={'X-aws-ec2-metadata-token-ttl-seconds': '21600'}, 
+                    verify=False
+                )
+            ).text
+            r = requests.get(
+                "http://169.254.169.254/latest/meta-data/instance-id",
+                headers={'X-aws-ec2-metadata-token': token}
+            )
         r.raise_for_status()
         return r.text
     except requests.exceptions.Timeout:

--- a/lib/botocore/utils.py
+++ b/lib/botocore/utils.py
@@ -174,15 +174,6 @@ class InstanceMetadataFetcher(object):
             else:
                 if response.status_code == 200:
                     return response
-                elif response.status_code == 401:
-                    token=(
-                        requests.put(
-                            "http://169.254.169.254/latest/api/token", 
-                            headers={'X-aws-ec2-metadata-token-ttl-seconds': '21600'}, 
-                            verify=False
-                        )
-                    ).text
-                    return requests.get(url, headers={'X-aws-ec2-metadata-token': token}, timeout=timeout)
         raise _RetriesExceededError()
 
     def retrieve_iam_role_credentials(self):

--- a/lib/botocore/utils.py
+++ b/lib/botocore/utils.py
@@ -174,6 +174,15 @@ class InstanceMetadataFetcher(object):
             else:
                 if response.status_code == 200:
                     return response
+                elif response.status_code == 401:
+                    token=(
+                        requests.put(
+                            "http://169.254.169.254/latest/api/token", 
+                            headers={'X-aws-ec2-metadata-token-ttl-seconds': '21600'}, 
+                            verify=False
+                        )
+                    ).text
+                    return requests.get(url, headers={'X-aws-ec2-metadata-token': token}, timeout=timeout)
         raise _RetriesExceededError()
 
     def retrieve_iam_role_credentials(self):


### PR DESCRIPTION
This PR handles the issue https://github.com/awslabs/aws-ec2rescue-linux/issues/58

Updated: 
.\ec2rlcore\awshelpers.py : get_instance_region and get_instance_id 
.\ec2rlcore\prediag.py : verify_metadata, get_virt_type and is_an_instance

IMDSv2 https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
