### PR TITLE
Adding modules amazonlinuxextras kpatch yumconfiguration

### DIFF
--- a/mod.d/amazonlinuxextras.yaml
+++ b/mod.d/amazonlinuxextras.yaml
@@ -1,0 +1,53 @@
+# Copyright 2016-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+--- !ec2rlcore.module.Module
+# Module document. Translates directly into an almost-complete Module object
+name: !!str amazonlinuxextras
+path: !!str
+version: !!str 1.0
+title: !!str Collect amazon-linux-extras list output
+helptext: !!str |
+  Collect amazon-linux-extras list output
+placement: !!str run
+package: 
+  - !!str 
+language: !!str bash
+content: !!str |
+  #!/bin/bash
+  error_trap()
+  {
+      printf "%0.s=" {1..80}
+      echo -e "\nERROR:	"$BASH_COMMAND" exited with an error on line ${BASH_LINENO[0]}"
+      exit 0
+  }
+  trap error_trap ERR
+
+  # read-in shared function
+  source functions.bash
+
+  echo "I will collect amazon-linux-extras list output from this $EC2RL_DISTRO box."
+
+  amazon-linux-extras list
+constraint:
+  requires_ec2: !!str False
+  domain: !!str os
+  class: !!str collect
+  distro: !!str alami2
+  required: !!str
+  optional: !!str
+  software: !!str
+  sudo: !!str False
+  perfimpact: !!str False
+  parallelexclusive: !!str

--- a/mod.d/amazonlinuxextras.yaml
+++ b/mod.d/amazonlinuxextras.yaml
@@ -47,7 +47,7 @@ constraint:
   distro: !!str alami2
   required: !!str
   optional: !!str
-  software: !!str
+  software: !!str amazon-linux-extras
   sudo: !!str False
   perfimpact: !!str False
   parallelexclusive: !!str

--- a/mod.d/kpatch.yaml
+++ b/mod.d/kpatch.yaml
@@ -47,7 +47,7 @@ constraint:
   distro: !!str alami2
   required: !!str
   optional: !!str
-  software: !!str 
+  software: !!str kpatch
   sudo: !!str False
   perfimpact: !!str False
   parallelexclusive: !!str

--- a/mod.d/kpatch.yaml
+++ b/mod.d/kpatch.yaml
@@ -1,0 +1,53 @@
+# Copyright 2016-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+--- !ec2rlcore.module.Module
+# Module document. Translates directly into an almost-complete Module object
+name: !!str kpatch
+path: !!str
+version: !!str 1.0
+title: !!str Collect kpatch list output
+helptext: !!str |
+  Collect kpatch list output
+placement: !!str run
+package: 
+  - !!str kpatch-runtime
+language: !!str bash
+content: !!str |
+  #!/bin/bash
+  error_trap()
+  {
+      printf "%0.s=" {1..80}
+      echo -e "\nERROR:	"$BASH_COMMAND" exited with an error on line ${BASH_LINENO[0]}"
+      exit 0
+  }
+  trap error_trap ERR
+
+  # read-in shared function
+  source functions.bash
+
+  echo "I will collect kpatch list output from this $EC2RL_DISTRO box."
+
+  kpatch list
+constraint:
+  requires_ec2: !!str False
+  domain: !!str os
+  class: !!str collect
+  distro: !!str alami2
+  required: !!str
+  optional: !!str
+  software: !!str 
+  sudo: !!str False
+  perfimpact: !!str False
+  parallelexclusive: !!str

--- a/mod.d/yumconfiguration.yaml
+++ b/mod.d/yumconfiguration.yaml
@@ -1,0 +1,55 @@
+# Copyright 2016-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+--- !ec2rlcore.module.Module
+# Module document. Translates directly into an almost-complete Module object
+name: !!str yumconfiguration
+path: !!str
+version: !!str 1.0
+title: !!str Collect yum related configuration file under /etc/yum* output
+helptext: !!str |
+  Collect yum related configuration file under /etc/yum* output
+placement: !!str run
+package: 
+  - !!str 
+language: !!str bash
+content: !!str |
+  #!/bin/bash
+  error_trap()
+  {
+      printf "%0.s=" {1..80}
+      echo -e "\nERROR:	"$BASH_COMMAND" exited with an error on line ${BASH_LINENO[0]}"
+      exit 0
+  }
+  trap error_trap ERR
+
+  # read-in shared function
+  source functions.bash
+
+  echo "I will collect all related yum configuration output from this $EC2RL_DISTRO box."
+  echo -e "\nYum repository list: \n\n"
+  yum repolist all
+  echo -e "\n------------------------------------------------------\n"
+  find /etc/yum* -type f -exec echo "File {} :" \; -exec cat {} \; -exec echo -e "\n------------------------------------------------------\n" \;
+constraint:
+  requires_ec2: !!str False
+  domain: !!str os
+  class: !!str collect
+  distro: !!str alami alami2 rhel
+  required: !!str
+  optional: !!str
+  software: !!str
+  sudo: !!str False
+  perfimpact: !!str False
+  parallelexclusive: !!str

--- a/mod.d/yumconfiguration.yaml
+++ b/mod.d/yumconfiguration.yaml
@@ -49,7 +49,7 @@ constraint:
   distro: !!str alami alami2 rhel
   required: !!str
   optional: !!str
-  software: !!str
+  software: !!str yum
   sudo: !!str False
   perfimpact: !!str False
   parallelexclusive: !!str


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

I am adding amazonlinuxextras kpatch yumconfiguration modules.
The three modules are collecting the following:
  - amazonlinuxextras : "amazon-linux-extras list" output that is useful when troubleshooting package related issue
  - kpatch: "kpatch list" output for troubleshooting kpatch related issue
  - yumconfiguration: collecting "yum repolist all" and all /etc/yum* configuration files, that are quite useful for troubleshooting package management related issue.
