### PR TITLE
Add xennetsgmtu net diagnostic module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [New Module] Add amazonlinuxextras os collect module.
 * [New Module] Add kpatch os collect module.
 * [New Module] Add yumconfiguration os collect module.
+* [New Module] Add xennetsgmtu net diagnostic module.
 
 #### Testing
 * [New Test] Add unit tests for is_nitro() function

--- a/docs/modules/xennetsgmtu.md
+++ b/docs/modules/xennetsgmtu.md
@@ -1,0 +1,55 @@
+# xennetsgmtu module
+
+## Problem Description
+
+EC2 instances utilizing paravirtual xen network drivers may see packet loss and intermittent communication problems when running on unpatched kernerls while interface MTU is set below Jumbo Frame size and Scatter Gather is disabled.
+
+## Detecting with EC2 Rescue for Linux
+
+EC2 Rescue for Linux includes a module that examines your interface configuration for susceptibility to this bug. This is provided by the 'xennetsgmtu' module. The module will run by default with sudo access and can be run individually.
+
+```
+./ec2rl run --only-modules=xennetsgmtu
+```
+
+```
+----------[Diagnostic Results]----------
+module run/xennetsgmtu             [SUCCESS] Scatter-Gather is enabled on eth0. This mitigates the bug.
+```
+
+or
+
+```
+----------[Diagnostic Results]----------
+module run/xennetsgmtu             [SUCCESS] MTU is set to Jumbo-Frame size on eth0. This mitigates the bug.
+```
+
+Warning output:
+
+```
+----------[Diagnostic Results]----------
+module run/xennetsgmtu      [WARN] Scatter-Gather is off and MTU is set below 9001 on eth0. You are potentially susceptible to the bug.
+```
+
+## Detecting Manually
+
+Susceptibility can be manually confirmed by checking ethtool and ifconfig configuration for the instance in question.
+
+```
+$ ethtool -k eth0 | grep "^scatter-gather: on"
+  scatter-gather: on
+$ ifconfig eth0 | grep "MTU:9001"
+            UP BROADCAST RUNNING MULTICAST  MTU:9001  Metric:1
+```
+If scatter-gather is returned as "off" or the MTU is returned as 1500, the system is potentially susceptible.
+Due to the kernel update that resolves the issue being delivered in a variety of versions across EC2RL support distributions, it is not within scope of this document to track known good kernels.
+
+## Resolution
+
+This error is best fixed by making sure you have moved to the latest kernel version provided by your distribution, or if on an instance capable of utilizing Enhanced Networking, using it rather than the paravirtual xennet driver. It can be worked around via setting MTU to 9001 for the interface on supporter instance types, or enabling scatter gather.
+
+Workaround configuration can be done as follows:
+```
+$ sudo ethtool -K eth0 sg on
+$ sudo ifconfig eth0 mtu 9001
+```

--- a/mod.d/xennetsgmtu.yaml
+++ b/mod.d/xennetsgmtu.yaml
@@ -1,0 +1,78 @@
+# Copyright 2016-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+--- !ec2rlcore.module.Module
+# Module document. Translates directly into an almost-complete Module object
+name: !!str xennetsgmtu
+path: !!str
+version: !!str 1.0
+title: !!str Attempts to detect possibility of xennet scattergather/mtu issue
+helptext: !!str |
+  Checks if interface configuration is potentially able to be effected by a bug with network communication when utilizing
+  xennet drivers when MTU is below jumbo-frame size and Scatter Gather is disabled.
+placement: !!str run
+package: 
+  - !!str
+language: !!str bash
+content: !!str |
+  #!/bin/bash
+  error_trap()
+  {
+      printf "%0.s=" {1..80}
+      echo -e "\nERROR:	"$BASH_COMMAND" exited with an error on line ${BASH_LINENO[0]}"
+      exit 0
+  }
+  trap error_trap ERR
+
+  # read-in shared function
+  source functions.bash
+
+  echo -e "Checking for if system is potentially effected by xennet SG/MTU bug'\n\n"
+
+  if [ "$EC2RL_VIRT_TYPE" = "nitro" ]; then
+        echo "[SUCCESS] This is not a Xen based platform. It cannot utilize the xennet drivers."
+        exit 0
+  fi
+
+  if [[ "$EC2RL_NET_DRIVER" != "xen_netfront" && "$EC2RL_NET_DRIVER" != "netfront" ]]; then
+      echo "[SUCCESS] Not using xen_netfront driver."
+      echo "Please see https://github.com/awslabs/aws-ec2rescue-linux/blob/master/docs/modules/xennetsgmtu.md for further details"
+      exit 0
+  fi
+
+  for i in $EC2RL_INTERFACES; do
+      if ethtool -k $i | grep "^scatter-gather: on" 2>&1 > /dev/null
+          then
+              echo "[SUCCESS] Scatter-Gather is enabled on $i. This mitigates the bug."
+      elif ifconfig $i | grep "MTU:9001"  2>&1 > /dev/null
+          then
+              echo "[SUCCESS] MTU is set to Jumbo-Frame size on $i. This mitigates the bug."
+      else
+              echo "[WARN] Scatter-Gather is off and MTU is set below 9001 on $i. You are potentially susceptible to the bug."
+              echo "-- You can enable Scatter-Gather with 'sudo ethtool -K $i sg on'"
+              echo "-- You can set MTU with 'sudo ifconfig $i mtu 9001'"
+      fi
+  done
+  echo "Please see https://github.com/awslabs/aws-ec2rescue-linux/blob/master/docs/modules/xennetsgmtu.md for further details"
+constraint:
+  requires_ec2: !!str False
+  domain: !!str net
+  class: !!str diagnose
+  distro: !!str alami alami2 ubuntu rhel suse
+  required: !!str
+  optional: !!str
+  software: !!str
+  sudo: !!str True
+  perfimpact: !!str False
+  parallelexclusive: !!str


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Two interesting details came up when testing this module

1) New versions of botocore require urllib3, and this is not installed by default on all distributions we support. I have opened https://github.com/awslabs/aws-ec2rescue-linux/issues/68 for this

2) Some distributions require sudo for ethtool and ifconfig, and others do not. We currently do not have a way to handle this in ec2rl. I have defaulted this to sudo required as a result. I'm not a huge fan of this, but managing sudo on a per distribution basis would require some significant work on our part, and this seems to be a fairly rare edge case, so I don't think we should scope any work for this at current.