### PR TITLE
Update requirements_test.txt to locked versions to resolve transitive …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [Misc] Create Ubuntu specific copies of bcc modules to reflect the Debian package adding -bpfcc to the binary file names.
 
 #### Testing
+* [Bugfix] Update requirements_test.txt to lock versions of transient dependencies causing issues for py2.7 builds
 
 # EC2 Rescue for Linux v1.1.5
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,11 +10,16 @@
 ###### Requirements with Version Specifiers ######
 #   See https://www.python.org/dev/peps/pep-0440/#version-specifiers
 backports.shutil_get_terminal_size >= 1.0.0; python_version < '3.3'
-configparser >= 3.5.0; python_version == '2.7'
+configparser == 4.0.2; python_version == '2.7'
 contextlib2 >= 0.5.4; python_version < '3.4'
 coverage >= 4.3.4
 mock >= 1.3.0 ; python_version >= '3.3'
 mock < 4.0.0 ; python_version == '2.7'
+werkzeug == 1.0.1 ; python_version == '2.7'
+jinja2 == 2.11.3 ; python_version == '2.7'
+markupsafe == 1.1.1 ; python_version == '2.7'
+setuptools-scm==5.0.0 ; python_version == '2.7'
+wheel==0.36.1 ; python_version == '2.7'
 moto == 0.4.31
 responses >= 0.5.1, < 0.10.3
 requests >= 2.9.0


### PR DESCRIPTION
…dependencies breaking on py2.7

Tested by having to un-break the CodePipeline building the s3 releases.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
