### PR TITLE
Add sosreport and supportconfig modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 #### Modules
 * [Misc] Create Ubuntu specific copies of bcc modules to reflect the Debian package adding -bpfcc to the binary file names.
 * [New Module] Add enadiag net diagnostic module.
+* [New Module] Add sosreport os gather module.
+* [New Module] Add supportconfig os gather module.
 
 #### Testing
 * [Bugfix] Update requirements_test.txt to lock versions of transient dependencies causing issues for py2.7 builds

--- a/mod.d/sosreport.yaml
+++ b/mod.d/sosreport.yaml
@@ -1,0 +1,55 @@
+# Copyright 2016-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+--- !ec2rlcore.module.Module
+# Module document. Translates directly into an almost-complete Module object
+name: !!str sosreport
+path: !!str
+version: !!str 1.0
+title: !!str Gather a sosreport
+helptext: !!str |
+  Gather an sosreport
+placement: !!str run
+package: 
+  - !!str
+language: !!str bash
+content: !!str |
+  #!/bin/bash
+  error_trap()
+  {
+      printf "%0.s=" {1..80}
+      echo -e "\nERROR:	"$BASH_COMMAND" exited with an error on line ${BASH_LINENO[0]}"
+      exit 0
+  }
+  trap error_trap ERR
+
+  # read-in shared function
+  source functions.bash
+
+  echo "I will gather the output of an sosreport"
+          
+  mkdir $EC2RL_GATHEREDDIR/sosreport 
+  sosreport --tmp-dir $EC2RL_GATHEREDDIR/sosreport --batch
+  echo "I have attempted to gather unsanitized sosreport output to $EC2RL_GATHEREDDIR/sosreport"
+constraint:
+  requires_ec2: !!str False
+  domain: !!str os
+  class: !!str gather
+  distro: !!str alami alami2 ubuntu rhel suse
+  required: !!str
+  optional: !!str
+  software: !!str sosreport
+  sudo: !!str True
+  perfimpact: !!str False
+  parallelexclusive: !!str

--- a/mod.d/sosreport.yaml
+++ b/mod.d/sosreport.yaml
@@ -46,7 +46,7 @@ constraint:
   requires_ec2: !!str False
   domain: !!str os
   class: !!str gather
-  distro: !!str alami alami2 ubuntu rhel suse
+  distro: !!str alami alami2 al2023 ubuntu rhel suse
   required: !!str
   optional: !!str
   software: !!str sosreport

--- a/mod.d/supportconfig.yaml
+++ b/mod.d/supportconfig.yaml
@@ -19,7 +19,7 @@ path: !!str
 version: !!str 1.0
 title: !!str Gather a supportconfig
 helptext: !!str |
-  Gather an sosreport
+  Gather a supportcopnfig
 placement: !!str run
 package: 
   - !!str
@@ -37,11 +37,11 @@ content: !!str |
   # read-in shared function
   source functions.bash
 
-  echo "I will gather the output of an sosreport"
+  echo "I will gather the output of a supportconfig"
           
   mkdir $EC2RL_GATHEREDDIR/supportconfig
   supportconfig -R $EC2RL_GATHEREDDIR/supportconfig
-  echo "I have attempted to gather unsanitized sosreport output to $EC2RL_GATHEREDDIR/sosreport"
+  echo "I have attempted to gather unsanitized supportconfig output to $EC2RL_GATHEREDDIR/supportconfig"
 constraint:
   requires_ec2: !!str False
   domain: !!str os

--- a/mod.d/supportconfig.yaml
+++ b/mod.d/supportconfig.yaml
@@ -1,0 +1,55 @@
+# Copyright 2016-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+--- !ec2rlcore.module.Module
+# Module document. Translates directly into an almost-complete Module object
+name: !!str supportconfig
+path: !!str
+version: !!str 1.0
+title: !!str Gather a supportconfig
+helptext: !!str |
+  Gather an sosreport
+placement: !!str run
+package: 
+  - !!str
+language: !!str bash
+content: !!str |
+  #!/bin/bash
+  error_trap()
+  {
+      printf "%0.s=" {1..80}
+      echo -e "\nERROR:	"$BASH_COMMAND" exited with an error on line ${BASH_LINENO[0]}"
+      exit 0
+  }
+  trap error_trap ERR
+
+  # read-in shared function
+  source functions.bash
+
+  echo "I will gather the output of an sosreport"
+          
+  mkdir $EC2RL_GATHEREDDIR/supportconfig
+  supportconfig -R $EC2RL_GATHEREDDIR/supportconfig
+  echo "I have attempted to gather unsanitized sosreport output to $EC2RL_GATHEREDDIR/sosreport"
+constraint:
+  requires_ec2: !!str False
+  domain: !!str os
+  class: !!str gather
+  distro: !!str suse
+  required: !!str
+  optional: !!str
+  software: !!str supportconfig
+  sudo: !!str True
+  perfimpact: !!str False
+  parallelexclusive: !!str


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Adds modules that gathers sosreport and supportconfig outputs